### PR TITLE
Distribute charts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -476,7 +476,7 @@ jobs:
           echo "VERSION=${commit_version}" >> $GITHUB_ENV
           echo "COMMIT=${commit_short}" >> $GITHUB_ENV
           echo "COMMIT_SHA=${commit_sha}" >> $GITHUB_ENV
-          echo "IMAGE_TAG=sha.${commit_short}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=g${commit_short}" >> $GITHUB_ENV
           echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
           # By default the container image is being pushed to the registry

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -380,9 +380,6 @@ jobs:
             exit 1
           fi
 
-      - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
-
       - name: Check chart CRDs are up to date
         working-directory: charts
         run: |
@@ -631,14 +628,6 @@ jobs:
             --source="${{ github.server_url }}/${{ github.repository }}" \
             --revision="${{ env.IMAGE_TAG }}@sha1:${{ env.COMMIT_SHA }}" \
             --reproducible
-
-      - name: Set up Helm
-        if: env.PUSH == 'true'
-        uses: azure/setup-helm@v4
-
-      - name: Install yq
-        if: env.PUSH == 'true'
-        uses: mikefarah/yq@master
 
       - name: Login to GHCR (Helm)
         if: env.PUSH == 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -380,6 +380,18 @@ jobs:
             exit 1
           fi
 
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Check chart CRDs are up to date
+        working-directory: charts
+        run: |
+          make update-crds
+          if git status --porcelain xata-cnpg/templates/crds | grep '^ M'; then
+            echo "Chart CRDs are out of date. Please run 'make update-crds' in the charts directory."
+            exit 1
+          fi
+
   buildx:
     name: Build containers
     needs:
@@ -464,7 +476,7 @@ jobs:
           echo "VERSION=${commit_version}" >> $GITHUB_ENV
           echo "COMMIT=${commit_short}" >> $GITHUB_ENV
           echo "COMMIT_SHA=${commit_sha}" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${tag_name,,}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=sha.${commit_short}" >> $GITHUB_ENV
           echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
           # By default the container image is being pushed to the registry
@@ -619,3 +631,23 @@ jobs:
             --source="${{ github.server_url }}/${{ github.repository }}" \
             --revision="${{ env.IMAGE_TAG }}@sha1:${{ env.COMMIT_SHA }}" \
             --reproducible
+
+      - name: Set up Helm
+        if: env.PUSH == 'true'
+        uses: azure/setup-helm@v4
+
+      - name: Install yq
+        if: env.PUSH == 'true'
+        uses: mikefarah/yq@master
+
+      - name: Login to GHCR (Helm)
+        if: env.PUSH == 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push Helm chart
+        if: env.PUSH == 'true'
+        working-directory: charts
+        run: |
+          make inject-tags IMAGE="${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/xata-cnpg" TAG="${{ env.IMAGE_TAG }}"
+          make push-charts

--- a/XATA.md
+++ b/XATA.md
@@ -25,12 +25,12 @@ This is Xata's fork of [CloudNativePG](https://github.com/cloudnative-pg/cloudna
 
 | Artifact | Location |
 |----------|----------|
-| Image | `ghcr.io/xataio/xata-cnpg:sha.<commit>` |
-| Chart | `oci://ghcr.io/xataio/xata-cnpg/charts/xata-cnpg:0.0.0-sha.<commit>` |
+| Image | `ghcr.io/xataio/xata-cnpg:g<commit>` |
+| Chart | `oci://ghcr.io/xataio/xata-cnpg/charts/xata-cnpg:0.0.0-g<commit>` |
 
 ### Versioning
 
-Both image and chart use the same version: `sha.<7-char-commit>`.
+Both image and chart use the same version: `g<7-char-commit>`.
 
 This means:
 - Every commit produces a unique, traceable version

--- a/XATA.md
+++ b/XATA.md
@@ -1,0 +1,42 @@
+# Xata Fork of CloudNativePG
+
+This is Xata's fork of [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg).
+
+## Development Workflow
+
+### Making Changes
+
+1. Make your code changes
+2. If CRDs changed, regenerate them:
+   ```bash
+   make manifests
+   cd charts && make update-crds
+   ```
+3. Test locally, commit, and open a PR
+
+### CI Pipeline
+
+**On every push:**
+- Runs linters and tests
+- Verifies CRDs are up to date (both `config/crd` and `charts/`)
+- Builds and pushes image + Helm chart
+
+**Artifacts:**
+
+| Artifact | Location |
+|----------|----------|
+| Image | `ghcr.io/xataio/xata-cnpg:sha.<commit>` |
+| Chart | `oci://ghcr.io/xataio/xata-cnpg/charts/xata-cnpg:0.0.0-sha.<commit>` |
+
+### Versioning
+
+Both image and chart use the same version: `sha.<7-char-commit>`.
+
+This means:
+- Every commit produces a unique, traceable version
+- Chart's `appVersion` matches the image tag
+- No "latest" tags - always explicit versions
+
+## Helm Chart
+
+See [charts/README.md](charts/README.md) for chart-specific documentation.

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -4,7 +4,7 @@ CHART_NAME := xata-cnpg
 CHART_REGISTRY ?= oci://ghcr.io/xataio/xata-cnpg/charts
 
 GIT_COMMIT_FULL := $(shell git rev-parse HEAD)
-GIT_COMMIT_SHORT := sha.$(shell printf '%.7s' $(GIT_COMMIT_FULL))
+GIT_COMMIT_SHORT := g$(shell printf '%.7s' $(GIT_COMMIT_FULL))
 
 env: # Print Makefile variables for debugging
 	@echo "CHART_NAME: $(CHART_NAME)"

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,0 +1,48 @@
+SHELL := /bin/bash
+
+CHART_NAME := xata-cnpg
+CHART_REGISTRY ?= oci://ghcr.io/xataio/xata-cnpg/charts
+
+GIT_COMMIT_FULL := $(shell git rev-parse HEAD)
+GIT_COMMIT_SHORT := sha.$(shell printf '%.7s' $(GIT_COMMIT_FULL))
+
+env: # Print Makefile variables for debugging
+	@echo "CHART_NAME: $(CHART_NAME)"
+	@echo "CHART_REGISTRY: $(CHART_REGISTRY)"
+	@echo "GIT_COMMIT_FULL: $(GIT_COMMIT_FULL)"
+	@echo "GIT_COMMIT_SHORT: $(GIT_COMMIT_SHORT)"
+
+# Update CRDs from operator source
+update-crds:
+	@echo "Updating CRDs from config/helm"
+	kustomize build ../config/helm > $(CHART_NAME)/templates/crds/crds.yaml
+
+# Inject image tag into chart values.yaml
+# Usage: make inject-tags IMAGE=ghcr.io/xataio/xata-cnpg TAG=g1234567
+inject-tags:
+	@echo "Injecting image $(IMAGE):$(TAG) into $(CHART_NAME)/values.yaml"
+	yq eval '.image.repository = "$(IMAGE)"' -i $(CHART_NAME)/values.yaml
+	yq eval '.image.tag = "$(TAG)"' -i $(CHART_NAME)/values.yaml
+
+# Version the chart with git commit
+version-chart:
+	@echo "Setting $(CHART_NAME) version to 0.0.0-$(GIT_COMMIT_SHORT)"
+	yq eval '.version = "0.0.0-$(GIT_COMMIT_SHORT)" | .appVersion = "$(GIT_COMMIT_SHORT)"' -i $(CHART_NAME)/Chart.yaml
+
+# Package and push chart
+push-chart: version-chart
+	@set -e; \
+	echo "Packaging $(CHART_NAME)"; \
+	helm package $(CHART_NAME); \
+	echo "Pushing $(CHART_NAME) to $(CHART_REGISTRY)"; \
+	helm push $(CHART_NAME)-0.0.0-$(GIT_COMMIT_SHORT).tgz $(CHART_REGISTRY); \
+	rm -f $(CHART_NAME)-0.0.0-$(GIT_COMMIT_SHORT).tgz
+
+# Push chart (run `make update-crds` locally if CRDs changed)
+push-charts: push-chart
+
+lint:
+	helm lint $(CHART_NAME)
+
+template:
+	helm template $(CHART_NAME) $(CHART_NAME)

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -12,10 +12,14 @@ env: # Print Makefile variables for debugging
 	@echo "GIT_COMMIT_FULL: $(GIT_COMMIT_FULL)"
 	@echo "GIT_COMMIT_SHORT: $(GIT_COMMIT_SHORT)"
 
-# Update CRDs from operator source
+# Update CRDs from operator source.
+# Wraps output with Helm conditional so users can skip CRD installation via values.yaml (crds.create: false).
+# This matches upstream's release process: https://github.com/cloudnative-pg/charts/blob/main/RELEASE.md
 update-crds:
 	@echo "Updating CRDs from config/helm"
-	kustomize build ../config/helm > $(CHART_NAME)/templates/crds/crds.yaml
+	@echo '{{- if .Values.crds.create }}' > $(CHART_NAME)/templates/crds/crds.yaml
+	@kustomize build ../config/helm >> $(CHART_NAME)/templates/crds/crds.yaml
+	@echo '{{- end }}' >> $(CHART_NAME)/templates/crds/crds.yaml
 
 # Inject image tag into chart values.yaml
 # Usage: make inject-tags IMAGE=ghcr.io/xataio/xata-cnpg TAG=g1234567

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,24 @@
+# xata-cnpg Helm Chart
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `update-crds` | Sync CRDs from `config/helm` into the chart |
+| `inject-tags` | Set image repo/tag in values.yaml |
+| `push-charts` | Version and push chart to OCI registry |
+| `lint` | Validate chart |
+| `template` | Render chart templates |
+
+## Local Testing
+
+```bash
+make inject-tags IMAGE=ghcr.io/xataio/xata-cnpg TAG=local
+make lint
+make template
+helm install xata-cnpg ./xata-cnpg -n cnpg-system --create-namespace
+```
+
+## Registry
+
+Charts are pushed to: `oci://ghcr.io/xataio/xata-cnpg/charts`

--- a/charts/README.md
+++ b/charts/README.md
@@ -22,3 +22,11 @@ helm install xata-cnpg ./xata-cnpg -n cnpg-system --create-namespace
 ## Registry
 
 Charts are pushed to: `oci://ghcr.io/xataio/xata-cnpg/charts`
+
+## CRDs
+
+CRDs are wrapped with `{{- if .Values.crds.create }}` so users can skip CRD installation by setting `crds.create: false` in values.yaml. This is useful when:
+- CRDs already exist from another installation
+- CRDs are managed separately (e.g., via GitOps)
+
+The `update-crds` target regenerates CRDs from `config/helm` and adds this wrapper automatically, matching [upstream's release process](https://github.com/cloudnative-pg/charts/blob/main/RELEASE.md).


### PR DESCRIPTION
Context:
* We pulled in the charts from the cloudnative charts repo (https://github.com/cloudnative-pg/charts)- which is different than the operator repo (https://github.com/cloudnative-pg/cloudnative-pg) in a previous PR

* The cnpg release process is manual (😿):
   * operator new version gets released
   * someone updates the charts by hand
   * same someone also updates a bunch of other config files - containing for instance the version
   * then a separate chart release
   
Improvements: no more manual (or very limited)
  * developer changes operator code.
  * if these changes touch the CRDs, the developer regenerates them by running make update-crds
  * if the developer does not, a step in the PR CI checks fails

The CI workflow will then push the image AND the charts with the same tag so we can identify who goes with who. 

The chart release is no longer manual