### PR TITLE
[Bugfix] For creating a child replica after the creation volumesnapshot has been deleted

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1253,7 +1253,7 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	job := specs.JoinReplicaInstance(*cluster, nodeSerial)
 
 	// If we can bootstrap this replica from a pre-existing source, we do it
-	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, cluster, backupList)
+	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, r.Client, cluster, backupList)
 	if storageSource != nil {
 		job = specs.RestoreReplicaInstance(*cluster, nodeSerial)
 	}

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -26,6 +26,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/xataio/xata-cnpg/api/v1"
 	"github.com/xataio/xata-cnpg/pkg/utils"
@@ -60,6 +61,7 @@ func GetCandidateStorageSourceForPrimary(
 // to be used to create a replica PVC
 func GetCandidateStorageSourceForReplica(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -94,6 +96,7 @@ func GetCandidateStorageSourceForReplica(
 
 	if result := getCandidateSourceFromBackupList(
 		ctx,
+		c,
 		cluster,
 		backupList,
 	); result != nil {
@@ -108,14 +111,15 @@ func GetCandidateStorageSourceForReplica(
 		return nil
 	}
 
-	// Try using the backup the Cluster has been bootstrapped from
-	return getCandidateSourceFromClusterDefinition(cluster)
+	// Try using the backup the Cluster has been bootstrapped from, if it still exists
+	return checkDataSourceExists(ctx, c, cluster.Namespace, getCandidateSourceFromClusterDefinition(cluster))
 }
 
 // getCandidateSourceFromBackupList gets a candidate storage source
 // given a backup list
 func getCandidateSourceFromBackupList(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -172,7 +176,9 @@ func getCandidateSourceFromBackupList(
 
 		contextLogger.Debug("found a backup that is a valid storage source candidate")
 
-		return getCandidateSourceFromBackup(backup)
+		if result := checkDataSourceExists(ctx, c, cluster.Namespace, getCandidateSourceFromBackup(backup)); result != nil {
+			return result
+		}
 	}
 
 	return nil
@@ -200,6 +206,41 @@ func getCandidateSourceFromBackup(backup *apiv1.Backup) *StorageSource {
 	}
 
 	return &result
+}
+
+// checkDataSourceExists verifies that the PGDATA VolumeSnapshot referenced
+// by a StorageSource still exists in the given namespace. Returns the source
+// unchanged if it exists, or nil if the snapshot is missing or on error.
+func checkDataSourceExists(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	source *StorageSource,
+) *StorageSource {
+	if source == nil {
+		return nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+
+	metadata, err := GetSourceMetadataOrNil(ctx, c, namespace, source.DataSource)
+	if err != nil {
+		contextLogger.Warning(
+			"error checking if VolumeSnapshot exists, skipping as storage source",
+			"error", err.Error(),
+			"snapshotName", source.DataSource.Name,
+		)
+		return nil
+	}
+	if metadata == nil {
+		contextLogger.Info(
+			"VolumeSnapshot no longer exists, skipping as storage source",
+			"snapshotName", source.DataSource.Name,
+		)
+		return nil
+	}
+
+	return source
 }
 
 // getCandidateSourceFromClusterDefinition gets a candidate storage source

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -23,9 +23,13 @@ import (
 	"context"
 	"time"
 
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/xataio/xata-cnpg/internal/scheme"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/xataio/xata-cnpg/api/v1"
 	"github.com/xataio/xata-cnpg/pkg/utils"
@@ -33,6 +37,24 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+const testNamespace = "test-ns"
+
+func makeSnapshot(name string) *volumesnapshotv1.VolumeSnapshot {
+	return &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+	}
+}
+
+func makeFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.BuildWithAllKnownScheme()).
+		WithObjects(objects...).
+		Build()
+}
 
 var _ = Describe("Storage configuration", func() {
 	cluster := &apiv1.Cluster{
@@ -54,9 +76,13 @@ var _ = Describe("Storage configuration", func() {
 })
 
 var _ = Describe("Storage source", func() {
+	const testNamespace = "test-ns"
 	pgDataSnapshotVolumeName := "pgdata-snapshot"
 	pgWalSnapshotVolumeName := "pgwal-snapshot"
 	clusterWithBootstrapSnapshot := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -85,6 +111,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithBackupSection := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -97,6 +126,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithPluginOnly := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -139,16 +171,18 @@ var _ = Describe("Storage source", func() {
 		When("we don't have backups", func() {
 			When("there's no source WAL archive", func() {
 				It("should return the correct source when choosing pgdata", func(ctx context.Context) {
+					cli := makeFakeClient(makeSnapshot(pgDataSnapshotVolumeName))
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, cli, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgDataSnapshotVolumeName))
 				})
 
 				It("should return the correct source when choosing pgwal", func(ctx context.Context) {
+					cli := makeFakeClient(makeSnapshot(pgDataSnapshotVolumeName))
 					source, err := NewPgWalCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, cli, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgWalSnapshotVolumeName))
@@ -157,10 +191,12 @@ var _ = Describe("Storage source", func() {
 
 			When("there's a source WAL archive", func() {
 				It("should return an empty storage source", func(ctx context.Context) {
+					cli := makeFakeClient()
 					clusterSourceWALArchive := clusterWithBootstrapSnapshot.DeepCopy()
 					clusterSourceWALArchive.Spec.Bootstrap.Recovery.Source = "test"
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 						ctx,
+						cli,
 						clusterSourceWALArchive,
 						apiv1.BackupList{},
 					))
@@ -168,12 +204,23 @@ var _ = Describe("Storage source", func() {
 					Expect(source).To(BeNil())
 				})
 			})
+
+			When("the bootstrap VolumeSnapshot has been deleted", func() {
+				It("should fall back to nil", func(ctx context.Context) {
+					cli := makeFakeClient()
+					source := GetCandidateStorageSourceForReplica(
+						ctx, cli, clusterWithBootstrapSnapshot, apiv1.BackupList{})
+					Expect(source).To(BeNil())
+				})
+			})
 		})
 
 		When("we have backups", func() {
 			It("should return the correct backup", func(ctx context.Context) {
+				cli := makeFakeClient(makeSnapshot("completed-backup"))
 				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 					ctx,
+					cli,
 					clusterWithBootstrapSnapshot,
 					backupList,
 				))
@@ -181,13 +228,28 @@ var _ = Describe("Storage source", func() {
 				Expect(source).ToNot(BeNil())
 				Expect(source.Name).To(Equal("completed-backup"))
 			})
+
+			It("should fall back to the bootstrap snapshot when the backup VolumeSnapshot has been deleted", func(ctx context.Context) {
+				cli := makeFakeClient(makeSnapshot(pgDataSnapshotVolumeName))
+				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+					ctx,
+					cli,
+					clusterWithBootstrapSnapshot,
+					backupList,
+				))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(source).ToNot(BeNil())
+				Expect(source.Name).To(Equal(pgDataSnapshotVolumeName))
+			})
 		})
 	})
 
 	When("not bootstrapping from a VolumeSnapshot with no backups", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
+			cli := makeFakeClient()
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				cli,
 				clusterWithBackupSection,
 				apiv1.BackupList{},
 			))
@@ -198,8 +260,10 @@ var _ = Describe("Storage source", func() {
 
 	When("not bootstrapping from a VolumeSnapshot with backups", func() {
 		It("should return the backup as storage source", func(ctx context.Context) {
+			cli := makeFakeClient(makeSnapshot("completed-backup"))
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				cli,
 				clusterWithBackupSection,
 				backupList,
 			))
@@ -209,8 +273,10 @@ var _ = Describe("Storage source", func() {
 		})
 
 		It("should return the backup as storage source when WAL archiving is via plugin only", func(ctx context.Context) {
+			cli := makeFakeClient(makeSnapshot("completed-backup"))
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				cli,
 				clusterWithPluginOnly,
 				backupList,
 			))
@@ -218,15 +284,27 @@ var _ = Describe("Storage source", func() {
 			Expect(source).ToNot(BeNil())
 			Expect(source.Name).To(Equal("completed-backup"))
 		})
+
+		It("should fall back to nil when the backup VolumeSnapshot has been deleted", func(ctx context.Context) {
+			cli := makeFakeClient()
+			source := GetCandidateStorageSourceForReplica(
+				ctx,
+				cli,
+				clusterWithBackupSection,
+				backupList,
+			)
+			Expect(source).To(BeNil())
+		})
 	})
 
 	When("there's no WAL archiving", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
 			clusterNoWalArchiving := clusterWithBackupSection.DeepCopy()
 			clusterNoWalArchiving.Spec.Backup = nil
-
+			cli := makeFakeClient()
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				cli,
 				clusterNoWalArchiving,
 				backupList,
 			))
@@ -317,10 +395,12 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		cli := makeFakeClient(makeSnapshot("completed-backup"))
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
@@ -338,11 +418,37 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		cli := makeFakeClient()
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
 		Expect(source).To(BeNil())
+	})
+
+	It("falls back to the next backup when the most recent snapshot is deleted", func(ctx context.Context) {
+		backupList := apiv1.BackupList{
+			Items: []apiv1.Backup{
+				objectStoreBackup,
+				nonCompletedBackup,
+				oldCompletedBackup,
+				completedBackup,
+			},
+		}
+		backupList.SortByReverseCreationTime()
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-6 * time.Hour)),
+			},
+		}
+		// Only the old backup's snapshot exists; the newest one is deleted
+		cli := makeFakeClient(makeSnapshot("bad-name"))
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
+		Expect(source).ToNot(BeNil())
+		Expect(source.DataSource.Name).To(Equal("bad-name"))
 	})
 })
 
@@ -377,6 +483,7 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -389,7 +496,8 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			// Status.PGDataImageInfo is nil here on purpose
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		cli := makeFakeClient(makeSnapshot("completed-backup"))
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
@@ -401,6 +509,7 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -415,7 +524,8 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		cli := makeFakeClient()
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 
@@ -426,6 +536,7 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         testNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -440,7 +551,8 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		cli := makeFakeClient()
+		source := getCandidateSourceFromBackupList(ctx, cli, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 })

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Storage source", func() {
 				Expect(source.Name).To(Equal("completed-backup"))
 			})
 
-			It("should fall back to the bootstrap snapshot when the backup VolumeSnapshot has been deleted", func(ctx context.Context) {
+			It("should use the bootstrap snapshot if the backup snapshot is deleted", func(ctx context.Context) {
 				cli := makeFakeClient(makeSnapshot(pgDataSnapshotVolumeName))
 				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 					ctx,

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-	"github.com/xataio/xata-cnpg/internal/scheme"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/xataio/xata-cnpg/api/v1"
+	"github.com/xataio/xata-cnpg/internal/scheme"
 	"github.com/xataio/xata-cnpg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"


### PR DESCRIPTION
The situation is described in this bug report here:  https://github.com/cloudnative-pg/cloudnative-pg/issues/10029

Until CNPG decides if they want it or not,  i created this PR for our distro

Note: yes there is a timeframe where it can happen that the vs is “seen” by our checks and the deleted before the job starts, or delete while the job is ongoing. 
In that case, if the PVC and then job is deleted, the next reconcile will go on to pick `pg_basebackup` and the replica creation will succeed.
Currently, we have no way of recovering outside of manually deleting parts of the Cluster spec - which also means we may need to suspend reconcile from the operator - or try to expose those parts through the Branch Spec.

 So i think for now it gives us a path forward and a fast way to recover from ths corner case