### PR TITLE
[CI] Fix CI workflow PR creation

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -480,7 +480,7 @@ jobs:
           # By default the container image is being pushed to the registry
           echo "PUSH=true" >> $GITHUB_ENV
 
-          # Check if commit message contains [create-pr] to create maki PR
+          # Check if commit message contains [create-pr] to create infra-new PR
           commit_message=$(git log -1 --pretty=format:'%s' "${commit_sha}")
           if [[ "$commit_message" == *"[create-pr]"* ]]; then
             echo "CREATE_PR=true" >> $GITHUB_ENV
@@ -649,15 +649,15 @@ jobs:
           make inject-tags IMAGE="${{ env.REGISTRY }}/${{ env.REPO }}/cloudnative-pg" TAG="${{ env.IMAGE_TAG }}"
           make push-charts VERSION="${{ env.IMAGE_TAG }}"
 
-      - name: Checkout maki repo
+      - name: Checkout infra-new repo
         if: env.PUSH == 'true' && env.CREATE_PR == 'true'
         uses: actions/checkout@v4
         with:
-          repository: xataio/maki
+          repository: xataio/infra-new
           token: ${{ secrets.GIT_TOKEN }}
-          path: maki-repo
+          path: infra-new-repo
 
-      - name: Create PR in maki for dev testing
+      - name: Create PR in infra-new for dev testing
         if: env.PUSH == 'true' && env.CREATE_PR == 'true'
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
@@ -665,9 +665,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          cd maki-repo
+          cd infra-new-repo
 
-          COMPONENT_FILE="kustomize/components/xata-cnpg-1.28.0/kustomization.yaml"
+          COMPONENT_FILE="kustomize/maki/components/xata-cnpg-1.28.0/kustomization.yaml"
 
           # Update the chart version in the component
           sed -i 's|version: 0.0.0-g[a-f0-9]*|version: '"$CHART_VERSION"'|g' "$COMPONENT_FILE"
@@ -702,7 +702,7 @@ jobs:
 
           if [[ -n "$EXISTING_PR" ]]; then
             echo "Updated existing PR #${EXISTING_PR}"
-            echo "PR URL: https://github.com/xataio/maki/pull/${EXISTING_PR}"
+            echo "PR URL: https://github.com/xataio/infra-new/pull/${EXISTING_PR}"
           else
             PR_URL=$(gh pr create \
               --title "Update cloudnative-pg to ${CHART_VERSION}" \

--- a/XATA.md
+++ b/XATA.md
@@ -27,9 +27,9 @@ This is Xata's fork of [CloudNativePG](https://github.com/cloudnative-pg/cloudna
 - Verifies CRDs are up to date (both `config/crd` and `charts/`)
 - Builds and pushes image + Helm chart
 
-**Creating a test PR in maki:**
+**Creating a test PR in infra-new:**
 
-Include `[create-pr]` in your commit message to automatically create a PR in the maki repo that updates the cloudnative-pg chart version. This is useful for testing changes in dev environments.
+Include `[create-pr]` in your commit message to automatically create a PR in the infra-new repo that updates the cloudnative-pg chart version. This is useful for testing changes in dev environments.
 
 ```bash
 git commit -m "My changes [create-pr]"


### PR DESCRIPTION
Fix the create PR step in the CI workflow so that it creates the PR against the `infra-new` repo, not `maki`.

The kustomization files have moved from `maki` to `infra-new`.

Example PR created against `infra-new`:  https://github.com/xataio/infra-new/pull/854

Before this change PR creation would fail, as in this run:

https://github.com/xataio/xata-cnpg/actions/runs/22391128056/job/64814199914