### PR TITLE
Pin setup-envtest for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ kustomize: ## Download kustomize locally if necessary.
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
 GENREF = $(LOCALBIN)/genref
 genref: ## Download kubernetes-sigs/reference-docs/genref locally if necessary.


### PR DESCRIPTION
I got this failure after merging #24: https://github.com/xataio/xata-cnpg/actions/runs/23831133427

This pins setup-envtest which should be a temporary fix. 

A better fix would be to merge #22 , but that's a bigger change.