### PR TITLE
Bump `controller-tools` version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ PGBOUNCER_IMAGE_NAME ?= $(shell grep 'DefaultPgbouncerImage.*=' "pkg/versions/ve
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=loose
 KUSTOMIZE_VERSION ?= v5.6.0
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
-CONTROLLER_TOOLS_VERSION ?= v0.19.0
+CONTROLLER_TOOLS_VERSION ?= 50567dcb # Use unreleased version for PR controller-tools##1327
 GENREF_VERSION ?= 015aaac611407c4fe591bc8700d2c67b7521efca
 # renovate: datasource=go depName=github.com/goreleaser/goreleaser
 GORELEASER_VERSION ?= v2.12.7

--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -465,7 +465,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -547,7 +547,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -7964,7 +7964,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8559,7 +8559,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8637,7 +8637,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8718,7 +8718,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -18028,7 +18028,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18224,7 +18224,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18427,7 +18427,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: backups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_clusterimagecatalogs.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusterimagecatalogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: clusters.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: databases.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_failoverquorums.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_failoverquorums.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: failoverquorums.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_imagecatalogs.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_imagecatalogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: imagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: poolers.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_publications.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_publications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: publications.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: scheduledbackups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1-0.20260221191338-50567dcb131b
   name: subscriptions.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io


### PR DESCRIPTION
Bump the version of `controller-tools` to the (unreleased) SHA `50567dcb`.

We need to take a recent `main` build of `controller-tools` so that we have a version that includes:

https://github.com/kubernetes-sigs/controller-tools/pull/1327

which adds support to the `controller-gen` tool for generating `ApplyConfigurations` for structs that embed types from external repos. With this support in place we can generate `ApplyConfigurations` for all CNPG types, allowing other tools/controllers/operators to interact with them using Server Side Apply.