### PR TITLE
[create-pr] Add `atomic` to `BootstrapConfiguration`

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1499,6 +1499,7 @@ type ExtensionConfiguration struct {
 // ones. `initdb` will be used as the bootstrap method if left
 // unspecified. Refer to the Bootstrap page of the documentation for more
 // information.
+// +structType=atomic
 type BootstrapConfiguration struct {
 	// Bootstrap the cluster via initdb
 	// +optional

--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -2828,6 +2828,7 @@ spec:
                         type: object
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               certificates:
                 description: The configuration for the CA and related certificates
                 properties:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2283,6 +2283,7 @@ spec:
                         type: object
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               certificates:
                 description: The configuration for the CA and related certificates
                 properties:


### PR DESCRIPTION
Make the `BootstrapConfiguration` struct atomic to ensure that any changes to it replace the entire configuration rather than merging with the existing one.

This matches the intended semantics of the type as a union of different bootstrap methods, where only one method should be active at a time.