### PR TITLE
[PgBackRest] re-create stanza if repo got wiped

### DIFF
--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -180,7 +180,26 @@ func internalRun(
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.IsPgBackRestConfigured() {
 		walPath := filepath.Join(pgData, walName)
 		contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
-		return pgbackrest.ArchivePush(ctx, cluster.Name, walPath)
+
+		err := pgbackrest.ArchivePush(ctx, cluster.Name, walPath)
+		if err == nil {
+			return nil
+		}
+
+		// If the stanza metadata (archive.info) was deleted from the repository,
+		// attempt to recreate it. This only succeeds when the S3 path is fully
+		// clean — if partial data remains, stanza-create will fail and the error
+		// is returned for manual intervention.
+		if pgbackrest.IsStanzaMissingFromRepo(err) {
+			contextLog.Warning("Stanza metadata missing from repository, recreating. " +
+				"Previous backups may be unavailable — a new full backup is recommended")
+			if stanzaErr := pgbackrest.StanzaCreate(ctx, cluster.Name); stanzaErr != nil {
+				return fmt.Errorf("failed to recreate stanza after metadata loss: %w", stanzaErr)
+			}
+			return pgbackrest.ArchivePush(ctx, cluster.Name, walPath)
+		}
+
+		return err
 	}
 
 	// Request Barman Cloud to archive this WAL

--- a/pkg/pgbackrest/command.go
+++ b/pkg/pgbackrest/command.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 )
@@ -54,6 +55,20 @@ func IsAvailable() bool {
 // does not exist in the repository. This is a normal condition — PostgreSQL
 // uses it to stop recovery or fall back to streaming replication.
 var ErrWALNotFound = errors.New("WAL segment not found in repository")
+
+// IsStanzaMissingFromRepo checks whether a pgbackrest error indicates that
+// the stanza metadata (archive.info) has been deleted from the repository.
+// This is exit code 103 with FileMissingError — meaning the info files are
+// gone but pgbackrest found no valid repository to operate against.
+// Recreating the stanza will only succeed if the S3 path is fully clean;
+// if partial data remains, stanza-create will fail separately.
+func IsStanzaMissingFromRepo(err error) bool {
+	var cmdErr *CommandError
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	return cmdErr.ExitCode == 103 && strings.Contains(cmdErr.Stderr, "FileMissingError")
+}
 
 // CommandError is returned when a pgbackrest command fails.
 type CommandError struct {

--- a/pkg/pgbackrest/command_test.go
+++ b/pkg/pgbackrest/command_test.go
@@ -21,6 +21,7 @@ package pgbackrest
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -100,5 +101,59 @@ func TestArchiveGet_WALNotFound(t *testing.T) {
 	// Verify ErrWALNotFound is a distinct error
 	if errors.Is(cmdErr, ErrWALNotFound) {
 		t.Error("CommandError should not be ErrWALNotFound directly")
+	}
+}
+
+func TestIsStanzaMissingFromRepo(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			"FileMissingError with exit 103",
+			&CommandError{
+				Command:  "archive-push",
+				ExitCode: 103,
+				Stderr:   "repo1: [FileMissingError] unable to load info file '/stanza/archive/stanza/archive.info'",
+			},
+			true,
+		},
+		{
+			"exit 103 without FileMissingError",
+			&CommandError{
+				Command:  "archive-push",
+				ExitCode: 103,
+				Stderr:   "repo1: [ArchiveMismatchError] PostgreSQL version 17, system-id 123 do not match",
+			},
+			false,
+		},
+		{
+			"FileMissingError with different exit code",
+			&CommandError{
+				Command:  "archive-push",
+				ExitCode: 1,
+				Stderr:   "[FileMissingError] something",
+			},
+			false,
+		},
+		{
+			"nil error",
+			nil,
+			false,
+		},
+		{
+			"non-CommandError",
+			fmt.Errorf("some error"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStanzaMissingFromRepo(tt.err); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION


###  Problem

  If the S3 stanza metadata (`archive.info`, `backup.info`) is deleted out of band, `archive-push` fails with exit code `103` and `FileMissingError` in the log output. 
 The reconciler's `pgBackRestStanzaCreated` flag is already true from the initial creation, so `stanza-create` never re-runs. WAL archiving is stuck until the pod is manually restarted.

 ### Fix

  When `archive-push` fails with exit `103` and `FileMissingError`, we automatically run `stanza-create `and retry the push. This self-heals the case where the entire S3 path has been wiped (e.g. cleaning up a test cluster, branch operator deleting a cluster's data).

 ### What it recovers

  Full S3 wipe (all info files + all data deleted):` stanza-create` succeeds because the directories are empty, archiving resumes immediately. A warning is logged that previous backups may be unavailable -which they weren't anyway since the directory was empty

### What it doesn't recover

  Partial deletion (e.g. info files deleted but backup/WAL data remains): `stanza-create` itself rejects the inconsistent state with `PathNotEmptyError` (exit 40). This requires manual intervention — we don't blindly overwrite existing data. The operator logs the error and the user can investigate.

  Other exit `103` errors (system-id mismatch, checksum errors, permission issues): These are not `FileMissingError`, so the check doesn't match. The error is returned as-is for normal handling.

  **Notes: How pgbackrest exit 103 works:**

  Exit `103` (`RepoInvalidError`) is a wrapper — pgbackrest collects per-repo errors during validation and throws them all as one error. The actual error type is embedded in the message (e.g. [`FileMissingError`], [`ArchiveMismatchError`]). 

`FileMissingError` is triggered when the info files are missing and the rest of the repo is empty. This is why it is safe to recreate. For all other cases, some data is in the repo - so human intervention is needed - either delete what is there or move it. 

_Using the log output and checking it for `FileMissingError` is brittle - since log messages can be changes and are not bound by any contract. 
We can consider introducing a one-shot annotation to allow recreating the stanza, that then gets removed after the action is executed. 
So far this should be enough - we update `pgbackrest` in a controlled fashion and when we do the next update we can consider improving if this approach proves painful/incomplete_
