### PR TITLE
Pin search_path in all operator connections

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -810,10 +810,15 @@ func (r *InstanceReconciler) reconcilePgbouncerAuthUser(
 		return err
 	}
 	if !existsFunction {
+		// SECURITY DEFINER functions run as the function owner (the cluster
+		// superuser here). Pin search_path to pg_catalog, pg_temp on the
+		// function itself so that operators inside the body cannot be
+		// resolved through the caller's search_path (CWE-426 hardening).
 		_, err = tx.Exec(fmt.Sprintf("CREATE OR REPLACE FUNCTION %s.%s(uname TEXT) "+
 			"RETURNS TABLE (usename name, passwd text) "+
 			"as '%s' "+
-			"LANGUAGE sql SECURITY DEFINER",
+			"LANGUAGE sql SECURITY DEFINER "+
+			"SET search_path = pg_catalog, pg_temp",
 			userSearchFunctionSchema,
 			userSearchFunctionName,
 			userSearchFunction))

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -436,11 +436,27 @@ func (info InitInfo) executeQueries(sqlUser *sql.DB, queries []string) error {
 		return nil
 	}
 
+	// User init scripts expect the standard "$user", public search_path; the
+	// connection pool pins search_path to pg_catalog at startup (CWE-426), so
+	// we bracket each query. The dedicated *sql.Conn keeps SET and the query
+	// on the same physical connection.
+	ctx := context.Background()
+	conn, err := sqlUser.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring dedicated connection for init queries: %w", err)
+	}
+	defer conn.Close()
+
 	for _, sqlQuery := range queries {
 		log.Debug("Executing query", "sqlQuery", sqlQuery)
-		_, err := sqlUser.Exec(sqlQuery)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, `SET search_path TO "$user", public`); err != nil {
+			return fmt.Errorf("setting search_path before init query: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, sqlQuery); err != nil {
 			return err
+		}
+		if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
+			return fmt.Errorf("resetting search_path after init query: %w", err)
 		}
 	}
 

--- a/pkg/management/postgres/initdb_test.go
+++ b/pkg/management/postgres/initdb_test.go
@@ -172,8 +172,14 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 		mockSuperUser.ExpectExec(`CREATE ROLE \"app_user\" LOGIN`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
+		// executeQueries brackets each user query with SET search_path / RESET
+		// so user-authored DDL still resolves into "$user", public.
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mockSuperUser.ExpectExec("CREATE ROLE post_init_role LOGIN").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		err := info.ConfigureNewInstance(mi)
 
@@ -188,8 +194,12 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 
 		// No direct role creation expected
 
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mockSuperUser.ExpectExec("CREATE ROLE post_init_role LOGIN").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// Execute function under test
 		err := info.ConfigureNewInstance(mi)
@@ -197,5 +207,52 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 		// Verify results
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mockSuperUser.ExpectationsWereMet()).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("executeQueries search_path bracketing", func() {
+	It("brackets each user query with SET search_path and RESET search_path", func() {
+		db, mock, err := sqlmock.New()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			_ = db.Close()
+		}()
+
+		mock.MatchExpectationsInOrder(true)
+		mock.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`CREATE TABLE foo (id int)`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`GRANT ALL ON foo TO app`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		info := InitInfo{}
+		err = info.executeQueries(db, []string{
+			"CREATE TABLE foo (id int)",
+			"GRANT ALL ON foo TO app",
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+	})
+
+	It("is a no-op when there are no queries", func() {
+		db, mock, err := sqlmock.New()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			_ = db.Close()
+		}()
+
+		info := InitInfo{}
+		err = info.executeQueries(db, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -575,6 +575,14 @@ func createMonitoringTx(conn *sql.DB) (*sql.Tx, error) {
 
 	// Set the pg_monitor role
 	_, err = tx.Exec("SET ROLE TO pg_monitor")
+	if err != nil {
+		return nil, err
+	}
+
+	// Operator-defined queries may reference unqualified objects in public.
+	// SET LOCAL is bounded by this transaction's end, so the pinned
+	// connection-level default is restored when the metrics tx commits.
+	_, err = tx.Exec("SET LOCAL search_path = pg_catalog, public")
 
 	return tx, err
 }

--- a/pkg/management/postgres/metrics/collector_test.go
+++ b/pkg/management/postgres/metrics/collector_test.go
@@ -223,6 +223,7 @@ var _ = Describe("QueryRunner tests", func() {
 			dbMock.ExpectExec("SET application_name TO cnpg_metrics_exporter").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectExec("SET standard_conforming_strings TO on").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectExec("SET ROLE TO pg_monitor").WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectExec("SET LOCAL search_path = pg_catalog, public").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectQuery(loPagesQuery).WillReturnRows(sqlmock.NewRows(
 				[]string{"datname", "lo_pages"}).
 				AddRow(`app`, 3))

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -84,4 +84,9 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 	// a standard date format for the operator to manage the dates
 	// when it's needed
 	config.RuntimeParams["datestyle"] = "ISO"
+
+	// Pin search_path so a tenant ALTER DATABASE / ALTER ROLE setting cannot
+	// influence operator-issued queries. User-SQL paths (initdb
+	// post-init scripts, custom monitoring queries) reset this explicitly.
+	config.RuntimeParams["search_path"] = "pg_catalog"
 }

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pool
+
+import (
+	"github.com/jackc/pgx/v5"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Connection profile defaults", func() {
+	parseConfig := func() *pgx.ConnConfig {
+		cfg, err := pgx.ParseConfig("host=/tmp")
+		Expect(err).ToNot(HaveOccurred())
+		return cfg
+	}
+
+	DescribeTable("pin search_path = pg_catalog in the startup packet",
+		func(profile ConnectionProfile) {
+			cfg := parseConfig()
+			profile.Enrich(cfg)
+
+			// CWE-426: every operator-issued connection must carry a
+			// fixed search_path so that no tenant-controlled ALTER
+			// DATABASE / ALTER ROLE setting can influence operator
+			// queries.
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "pg_catalog"))
+
+			// Verify the pre-existing defaults are still present.
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("datestyle", "ISO"))
+		},
+		Entry("ConnectionProfilePostgresql", ConnectionProfilePostgresql),
+		Entry("ConnectionProfilePostgresqlPhysicalReplication", ConnectionProfilePostgresqlPhysicalReplication),
+		Entry("ConnectionProfilePgbouncer", ConnectionProfilePgbouncer),
+	)
+
+	It("preserves the synchronous_commit override on the postgresql profile", func() {
+		cfg := parseConfig()
+		ConnectionProfilePostgresql.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("synchronous_commit", "local"))
+	})
+
+	It("preserves the replication=1 override on the physical-replication profile", func() {
+		cfg := parseConfig()
+		ConnectionProfilePostgresqlPhysicalReplication.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("replication", "1"))
+	})
+})

--- a/pkg/management/postgres/wal.go
+++ b/pkg/management/postgres/wal.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/xataio/xata-cnpg/pkg/management/postgres/pool"
 	"github.com/xataio/xata-cnpg/pkg/resources"
 )
 
@@ -63,10 +64,7 @@ type walArchiveAnalyzer struct {
 func newWalArchiveAnalyzerForReplicaInstance(primaryConnInfo string) *walArchiveAnalyzer {
 	return &walArchiveAnalyzer{
 		dbFactory: func() (*sql.DB, error) {
-			db, openErr := sql.Open(
-				"pgx",
-				primaryConnInfo,
-			)
+			db, openErr := pool.NewDBConnection(primaryConnInfo, pool.ConnectionProfilePostgresql)
 			if openErr != nil {
 				log.Error(openErr, "can not open postgres database")
 				return nil, openErr
@@ -129,12 +127,12 @@ func newWalArchiveBootstrapperForPrimary() *walArchiveBootstrapper {
 	return &walArchiveBootstrapper{
 		walArchiveAnalyzer: walArchiveAnalyzer{
 			dbFactory: func() (*sql.DB, error) {
-				db, openErr := sql.Open(
-					"pgx",
+				db, openErr := pool.NewDBConnection(
 					fmt.Sprintf("host=%s port=%v dbname=postgres user=postgres sslmode=disable",
 						GetSocketDir(),
 						GetServerPort(),
 					),
+					pool.ConnectionProfilePostgresql,
 				)
 				if openErr != nil {
 					log.Error(openErr, "can not open postgres database")

--- a/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
@@ -1,0 +1,52 @@
+# Cluster used by the search_path operator hijack regression test (CWE-426).
+#
+# bootstrap.initdb.postInitApplicationSQL plants attacker-controlled `>` and `=`
+# operators in the application database's `public` schema and flips the
+# database-level search_path so that those operators are resolved before the
+# pg_catalog ones. After bootstrap completes, the e2e test triggers a
+# reconcile that runs reconcileExtensions; the patched operator must NOT
+# execute the planted operator bodies, so the application user must remain a
+# regular (non-superuser) role.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: p-search-path-hijack
+spec:
+  instances: 1
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      postInitApplicationSQL:
+        # Plant a function that, if it ever runs, would try to elevate the
+        # application user to SUPERUSER. The function is intentionally a
+        # PL/pgSQL function bound to a custom `>` operator; the patched
+        # operator's probes pin search_path to pg_catalog at startup, so
+        # this body must never execute on a CNPG-issued connection.
+        - |
+          CREATE OR REPLACE FUNCTION public.shadow_gt(a bigint, b integer) RETURNS boolean
+            LANGUAGE plpgsql AS $$
+            BEGIN
+              EXECUTE 'ALTER ROLE ' || quote_ident(current_user) || ' SUPERUSER';
+              RETURN a > b;
+            END;
+            $$;
+        - CREATE OPERATOR public.> (LEFTARG=bigint, RIGHTARG=integer, FUNCTION=public.shadow_gt);
+        - |
+          CREATE OR REPLACE FUNCTION public.shadow_eq(a name, b name) RETURNS boolean
+            LANGUAGE plpgsql AS $$ BEGIN RETURN a::text = b::text; END; $$;
+        - CREATE OPERATOR public.= (LEFTARG=name, RIGHTARG=name, FUNCTION=public.shadow_eq);
+        # Flip the database-level search_path so that, on connections where
+        # the operator does NOT pin search_path, the planted operators take
+        # precedence over pg_catalog.
+        - ALTER DATABASE app SET search_path = public, pg_catalog;
+
+  postgresql:
+    parameters:
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -148,6 +148,77 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 		})
 	})
 
+	// Regression test for CWE-426 search_path operator hijack
+	// (CNPG-PROBE-SEARCH-PATH-OPERATOR-HIJACK). A database-owner who plants
+	// shadow `>` and `=` operators in `public` and flips the database
+	// search_path must NOT be able to elevate to PostgreSQL superuser via
+	// the operator's introspection probes.
+	Context("search_path operator hijack negative", func() {
+		const (
+			clusterName    = "p-search-path-hijack"
+			clusterFixture = fixturesInitdbDir + "/cluster-postinit-search-path-hijack.yaml.template"
+		)
+
+		var namespace string
+
+		It("does not elevate the application role to superuser through probe queries", func() {
+			const namespacePrefix = "initdb-search-path-hijack"
+			var err error
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			AssertCreateCluster(namespace, clusterName, clusterFixture, env)
+
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying the application role is not a superuser after bootstrap", func() {
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT rolsuper FROM pg_catalog.pg_roles WHERE rolname = 'app'")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.TrimSpace(stdout)).To(Equal("f"))
+			})
+
+			By("verifying the application role is still not a superuser after reconcile cycles", func() {
+				// The instance manager reconciles managed extensions on a
+				// schedule. Wait long enough for at least one reconcile to
+				// run after bootstrap, then re-check that the planted
+				// operators were not invoked.
+				Eventually(func() (string, error) {
+					stdout, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{
+							Namespace: namespace,
+							PodName:   primary.Name,
+						}, "app",
+						"SELECT current_setting('is_superuser')")
+					return strings.TrimSpace(stdout), err
+				}, "60s", "5s").Should(Equal("off"))
+			})
+
+			By("verifying the planted shadow_gt function was never invoked", func() {
+				// shadow_gt's body issues `ALTER ROLE ... SUPERUSER` on
+				// invocation. If it ever fired, the role would now be
+				// superuser. We already asserted it is not, but this is the
+				// belt-and-braces check that the body itself never executed.
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT pg_catalog.count(*)::text FROM pg_catalog.pg_roles WHERE rolname = 'app' AND rolsuper")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.TrimSpace(stdout)).To(Equal("0"))
+			})
+		})
+	})
+
 	Context("custom default locale", func() {
 		const (
 			clusterName        = "p-locale"


### PR DESCRIPTION
It's important that the search path doesn't resolve `public` before `pg_catalog` for almost all connections done by the operator. This is a fairly systematic fix by changing it in the CNPG internal connection pool, then reverting where actually needed and safe.