### PR TITLE
[Connection pooler] Do not pin `search_path` when connecting to PgBouncer admin console

### DIFF
--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -39,6 +39,7 @@ type connectionProfilePostgresql profile
 
 func (connectionProfilePostgresql) Enrich(config *pgx.ConnConfig) {
 	fillDefaultParameters(config)
+	pinSearchPath(config)
 
 	// We don't want to be stuck on queries if synchronous replicas
 	// are still not alive and kicking. The next reconciliation loop
@@ -50,6 +51,7 @@ type connectionProfilePostgresqlPhysicalReplication profile
 
 func (connectionProfilePostgresqlPhysicalReplication) Enrich(config *pgx.ConnConfig) {
 	fillDefaultParameters(config)
+	pinSearchPath(config)
 
 	// The simple query protocol is needed since we're going to use
 	// this function to connect to the PgBouncer administrative
@@ -84,8 +86,10 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 	// a standard date format for the operator to manage the dates
 	// when it's needed
 	config.RuntimeParams["datestyle"] = "ISO"
+}
 
-	// Pin search_path via the startup packet so it cannot be overridden by
-	// database- or role-level defaults.
+// pinSearchPath pins search_path via the startup packet so it cannot be overridden by
+// database- or role-level defaults.
+func pinSearchPath(config *pgx.ConnConfig) {
 	config.RuntimeParams["search_path"] = `"$user", public`
 }

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -46,8 +46,19 @@ var _ = Describe("Connection profile defaults", func() {
 		},
 		Entry("ConnectionProfilePostgresql", ConnectionProfilePostgresql),
 		Entry("ConnectionProfilePostgresqlPhysicalReplication", ConnectionProfilePostgresqlPhysicalReplication),
-		Entry("ConnectionProfilePgbouncer", ConnectionProfilePgbouncer),
 	)
+
+	It("does not pin search_path on the pgbouncer profile", func() {
+		// PgBouncer's admin console rejects unknown startup parameters with
+		// SQLSTATE 08P01, and the admin connection never reaches PostgreSQL,
+		// so there is no CWE-426 vector to defend against here.
+		cfg := parseConfig()
+		ConnectionProfilePgbouncer.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).ToNot(HaveKey("search_path"))
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("datestyle", "ISO"))
+	})
 
 	It("preserves the synchronous_commit override on the postgresql profile", func() {
 		cfg := parseConfig()


### PR DESCRIPTION
PgBouncer's admin console rejects unknown startup parameters, so pinning `search_path` in `fillDefaultParameters` made every metrics collection fail:

```
FATAL: unsupported startup parameter: search_path (SQLSTATE 08P01)
```

This PR moves the pin into a dedicated `pinSearchPath` helper called only from the PostgreSQL connection profiles. The CWE-426 protection from #58 only matters for connections that reach PostgreSQL. As the admin console terminates inside pgbouncer, a tenant `ALTER ROLE` and `ALTER DATABASE` default cannot influence it.