### PR TITLE
Remove user from search path

### DIFF
--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -276,10 +276,26 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 		sqlCreateExtension.WriteString(fmt.Sprintf(" SCHEMA %s", pgx.Identifier{ext.Schema}.Sanitize()))
 	}
 
-	_, err := db.ExecContext(ctx, sqlCreateExtension.String())
+	// The connection is pinned to search_path = pg_catalog. Relocatable
+	// extensions whose install scripts contain unqualified CREATEs (and
+	// where the spec did not pin a SCHEMA) need a writable schema visible
+	// during the install. SET LOCAL inside a transaction reverts on
+	// COMMIT / ROLLBACK, so the connection state is not leaked.
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
+		return fmt.Errorf("starting transaction for CREATE EXTENSION: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL search_path TO public"); err != nil {
+		return fmt.Errorf("setting search_path before CREATE EXTENSION: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, sqlCreateExtension.String()); err != nil {
 		contextLogger.Error(err, "while creating extension", "query", sqlCreateExtension.String())
 		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing CREATE EXTENSION: %w", err)
 	}
 	contextLogger.Info("created extension", "name", ext.Name)
 
@@ -324,8 +340,24 @@ func updateDatabaseExtension(ctx context.Context, db *sql.DB, spec apiv1.Extensi
 			pgx.Identifier{spec.Version}.Sanitize(),
 		)
 
-		if _, err := db.ExecContext(ctx, changeVersionSQL); err != nil {
+		// ALTER EXTENSION ... UPDATE TO runs version-upgrade SQL scripts
+		// shipped with the extension; those scripts can contain unqualified
+		// CREATEs. Bracket with SET LOCAL search_path TO public for the
+		// same reason as createDatabaseExtension.
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("starting transaction for ALTER EXTENSION UPDATE: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		if _, err := tx.ExecContext(ctx, "SET LOCAL search_path TO public"); err != nil {
+			return fmt.Errorf("setting search_path before ALTER EXTENSION UPDATE: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, changeVersionSQL); err != nil {
 			return fmt.Errorf("altering version: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("committing ALTER EXTENSION UPDATE: %w", err)
 		}
 
 		contextLogger.Info("altered extension version", "name", spec.Name, "version", spec.Version)

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -293,16 +293,29 @@ var _ = Describe("Managed Extensions SQL", func() {
 		createExtensionSQL := "CREATE EXTENSION \"testext\" VERSION \"1.0\" SCHEMA \"default\""
 
 		It("returns success when the extension has been created", func(ctx SpecContext) {
+			// CREATE EXTENSION runs inside a transaction with
+			// SET LOCAL search_path TO public so relocatable extensions can
+			// install into a writable schema (CWE-426 hardening).
+			dbMock.ExpectBegin()
+			dbMock.
+				ExpectExec("SET LOCAL search_path TO public").
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectCommit()
 			Expect(createDatabaseExtension(ctx, db, ext)).Error().NotTo(HaveOccurred())
 		})
 
 		It("fails when the extension could not be created", func(ctx SpecContext) {
+			dbMock.ExpectBegin()
+			dbMock.
+				ExpectExec("SET LOCAL search_path TO public").
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnError(testError)
+			dbMock.ExpectRollback()
 			Expect(createDatabaseExtension(ctx, db, ext)).Error().To(Equal(testError))
 		})
 	})
@@ -337,9 +350,17 @@ var _ = Describe("Managed Extensions SQL", func() {
 		})
 
 		It("updates the extension version", func(ctx SpecContext) {
+			// ALTER EXTENSION ... UPDATE TO runs upgrade scripts that may
+			// contain unqualified CREATE statements; bracket with
+			// SET LOCAL search_path TO public.
+			dbMock.ExpectBegin()
+			dbMock.
+				ExpectExec("SET LOCAL search_path TO public").
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec("ALTER EXTENSION \"testext\" UPDATE TO \"1.0\"").
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectCommit()
 
 			Expect(updateDatabaseExtension(ctx, db, ext,
 				&extInfo{Name: ext.Name, Version: "0.9", Schema: ext.Schema})).Error().NotTo(HaveOccurred())
@@ -358,9 +379,14 @@ var _ = Describe("Managed Extensions SQL", func() {
 			dbMock.
 				ExpectExec("ALTER EXTENSION \"testext\" SET SCHEMA \"default\"").
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectBegin()
+			dbMock.
+				ExpectExec("SET LOCAL search_path TO public").
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec("ALTER EXTENSION \"testext\" UPDATE TO \"1.0\"").
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectCommit()
 
 			Expect(updateDatabaseExtension(ctx, db, ext, &extInfo{
 				Name: ext.Name, Version: "0.9",
@@ -381,9 +407,14 @@ var _ = Describe("Managed Extensions SQL", func() {
 			dbMock.
 				ExpectExec("ALTER EXTENSION \"testext\" SET SCHEMA \"default\"").
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectBegin()
+			dbMock.
+				ExpectExec("SET LOCAL search_path TO public").
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec("ALTER EXTENSION \"testext\" UPDATE TO \"1.0\"").
 				WillReturnError(testError)
+			dbMock.ExpectRollback()
 
 			Expect(updateDatabaseExtension(ctx, db, ext, &extInfo{
 				Name: ext.Name, Version: "0.9",

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -745,7 +745,20 @@ func (r *InstanceReconciler) reconcileExtensions(
 		// a DDL when it is not really needed.
 
 		if !extension.SkipCreateExtension && extensionIsUsed && !extensionIsInstalled {
-			_, err = tx.Exec(fmt.Sprintf("CREATE EXTENSION %s", extension.Name))
+			// The connection is pinned to search_path = pg_catalog;
+			// relocatable extensions whose install scripts contain
+			// unqualified CREATEs need a writable schema. Bracket only
+			// the CREATE so the rest of the transaction continues
+			// resolving operators out of pg_catalog.
+			if _, err = tx.Exec("SET search_path TO public"); err != nil {
+				break
+			}
+			if _, err = tx.Exec(fmt.Sprintf("CREATE EXTENSION %s", extension.Name)); err != nil {
+				break
+			}
+			if _, err = tx.Exec("RESET search_path"); err != nil {
+				break
+			}
 		} else if !extensionIsUsed && extensionIsInstalled {
 			_, err = tx.Exec(fmt.Sprintf("DROP EXTENSION %s", extension.Name))
 		}

--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -285,10 +285,27 @@ func (ds *databaseSnapshotter) executePostImportQueries(
 		return err
 	}
 
+	// User-supplied queries expect the standard "$user", public search_path;
+	// the connection pool pins search_path to pg_catalog at startup, so we
+	// bracket each query. The dedicated *sql.Conn keeps SET and the query
+	// on the same physical connection.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring dedicated connection for post-import queries: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
 	for _, query := range postImportQueries {
-		_, err := db.Exec(query)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, `SET search_path TO "$user", public`); err != nil {
+			return fmt.Errorf("setting search_path before post-import query: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, query); err != nil {
 			return err
+		}
+		if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
+			return fmt.Errorf("resetting search_path after post-import query: %w", err)
 		}
 	}
 

--- a/pkg/management/postgres/logicalimport/database_test.go
+++ b/pkg/management/postgres/logicalimport/database_test.go
@@ -110,13 +110,22 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 		})
 
 		It("should execute the query properly", func(ctx SpecContext) {
+			// Each user-supplied query is bracketed by
+			// SET search_path TO "$user", public / RESET search_path so
+			// the connection-level pg_catalog pin does not affect user DDL.
+			mock.ExpectExec(`SET search_path TO "$user", public`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec(createQuery).WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectExec(`RESET search_path`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			err := ds.executePostImportQueries(ctx, fp, "test")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return any error encountered", func(ctx SpecContext) {
 			expectedErr := fmt.Errorf("will fail")
+			mock.ExpectExec(`SET search_path TO "$user", public`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec(createQuery).WillReturnError(expectedErr)
 			err := ds.executePostImportQueries(ctx, fp, "test")
 			Expect(err).To(Equal(expectedErr))

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -86,6 +86,7 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 	config.RuntimeParams["datestyle"] = "ISO"
 
 	// Pin search_path via the startup packet so it cannot be overridden by
-	// database- or role-level defaults.
-	config.RuntimeParams["search_path"] = `"$user", public`
+	// database- or role-level defaults. pg_catalog is implicitly searched
+	// first when not listed; "$user" is intentionally omitted.
+	config.RuntimeParams["search_path"] = "public"
 }

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -86,7 +86,8 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 	config.RuntimeParams["datestyle"] = "ISO"
 
 	// Pin search_path via the startup packet so it cannot be overridden by
-	// database- or role-level defaults. pg_catalog is implicitly searched
-	// first when not listed; "$user" is intentionally omitted.
-	config.RuntimeParams["search_path"] = "public"
+	// database- or role-level defaults. Code paths that need a writable
+	// schema (CREATE EXTENSION, user-supplied SQL) opt in by setting
+	// search_path locally for the duration of that operation.
+	config.RuntimeParams["search_path"] = "pg_catalog"
 }

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Connection profile defaults", func() {
 			cfg := parseConfig()
 			profile.Enrich(cfg)
 
-			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", `"$user", public`))
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "public"))
 
 			// Verify the pre-existing defaults are still present.
 			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Connection profile defaults", func() {
 			cfg := parseConfig()
 			profile.Enrich(cfg)
 
-			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "public"))
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "pg_catalog"))
 
 			// Verify the pre-existing defaults are still present.
 			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))

--- a/tests/e2e/fixtures/initdb/cluster-postinit-extension-schema.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-extension-schema.yaml.template
@@ -1,11 +1,11 @@
 # Cluster used by the search_path / extension-creation regression test.
 #
 # A tenant DB-owner pre-creates a schema named after the operator's role
-# (`postgres`) and authorizes it to the application owner. With a connection
-# search_path of `"$user", public`, that schema would become the default
-# creation schema for operator-issued `CREATE EXTENSION` calls; the operator
-# pins search_path to `public`, so the next reconcileExtensions cycle must
-# still install pg_stat_statements into `public`.
+# (`postgres`) and authorizes it to the application owner. The operator
+# connection is pinned to search_path = pg_catalog and brackets each
+# CREATE EXTENSION with SET LOCAL search_path TO public, so the next
+# reconcileExtensions cycle must still install pg_stat_statements into
+# `public` regardless of the tenant-created `postgres` schema.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/tests/e2e/fixtures/initdb/cluster-postinit-extension-schema.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-extension-schema.yaml.template
@@ -1,0 +1,36 @@
+# Cluster used by the search_path / extension-creation regression test.
+#
+# A tenant DB-owner pre-creates a schema named after the operator's role
+# (`postgres`) and authorizes it to the application owner. With a connection
+# search_path of `"$user", public`, that schema would become the default
+# creation schema for operator-issued `CREATE EXTENSION` calls; the operator
+# pins search_path to `public`, so the next reconcileExtensions cycle must
+# still install pg_stat_statements into `public`.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: p-extension-schema
+spec:
+  instances: 1
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      postInitApplicationSQL:
+        # Pre-create a schema with the same name as the role the operator
+        # connects as; "$user" in a tenant-controlled search_path would
+        # resolve here.
+        - CREATE SCHEMA postgres AUTHORIZATION app;
+
+  postgresql:
+    parameters:
+      # Triggers reconcileExtensions to CREATE EXTENSION pg_stat_statements
+      # on the application database via an operator-issued connection.
+      pg_stat_statements.track: 'all'
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -219,6 +219,70 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 		})
 	})
 
+	// Operator-issued `CREATE EXTENSION` must land in `public` even when a
+	// tenant has pre-created a schema matching the operator's role name.
+	Context("extension creation schema is not redirected by tenant-owned $user schema", func() {
+		const (
+			clusterName    = "p-extension-schema"
+			clusterFixture = fixturesInitdbDir + "/cluster-postinit-extension-schema.yaml.template"
+		)
+
+		var namespace string
+
+		It("installs pg_stat_statements into public, not into the tenant-created postgres schema", func() {
+			const namespacePrefix = "initdb-extension-schema"
+			var err error
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			AssertCreateCluster(namespace, clusterName, clusterFixture, env)
+
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("confirming the tenant-owned postgres schema exists", func() {
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT pg_catalog.pg_get_userbyid(nspowner) FROM pg_catalog.pg_namespace "+
+						"WHERE nspname = 'postgres'")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.TrimSpace(stdout)).To(Equal("app"))
+			})
+
+			By("waiting for reconcileExtensions to install pg_stat_statements", func() {
+				Eventually(func() (string, error) {
+					stdout, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{
+							Namespace: namespace,
+							PodName:   primary.Name,
+						}, "app",
+						"SELECT pg_catalog.count(*)::text FROM pg_catalog.pg_extension "+
+							"WHERE extname = 'pg_stat_statements'")
+					return strings.TrimSpace(stdout), err
+				}, "60s", "5s").Should(Equal("1"))
+			})
+
+			By("verifying pg_stat_statements landed in public, not in the postgres schema", func() {
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT n.nspname FROM pg_catalog.pg_extension e "+
+						"JOIN pg_catalog.pg_namespace n ON e.extnamespace = n.oid "+
+						"WHERE e.extname = 'pg_stat_statements'")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.TrimSpace(stdout)).To(Equal("public"))
+			})
+		})
+	})
+
 	Context("custom default locale", func() {
 		const (
 			clusterName        = "p-locale"


### PR DESCRIPTION
This is a follow-up for #58 and #59 . #58 was too strict and broke pg_stat_satements, then #59 fixed it was rather wide, setting `$user, public` on all connections.

This one does more work but finds a better middle-ground by setting the search_path depending on needs, and defaults to the most safe option (`pg_catalog`).