### PR TITLE
Make pgBackRest stanza configurable

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -139,6 +139,13 @@ const (
 type PgBackRestConfiguration struct {
 	Repository *PgBackRestRepository `json:"repository"`
 	Options    *PgBackRestOptions    `json:"options,omitempty"`
+
+	// StanzaName is the pgbackrest stanza this cluster archives to. It is the
+	// logical identity of the backup set in the repository (the repo layout is
+	// <repoPath>/{archive,backup}/<stanza>/). When unset it defaults to the
+	// cluster name.
+	// +optional
+	StanzaName string `json:"stanzaName,omitempty"`
 }
 
 // PgBackRestExternalCluster defines the pgbackrest configuration for an external cluster,

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1341,6 +1341,20 @@ func (backupConfiguration *BackupConfiguration) IsPgBackRestConfigured() bool {
 		backupConfiguration.PgBackRest.Repository != nil
 }
 
+// GetPgBackRestStanzaName returns the pgbackrest stanza name used for this
+// cluster's own backups and WAL archiving. It defaults to the cluster name but
+// can be overridden via spec.backup.pgBackRest.stanzaName, so that backups stay
+// under a stable identity even when the underlying Cluster is recreated (e.g.
+// warm-pool wakeups, where the live cluster name changes between incarnations).
+func (cluster *Cluster) GetPgBackRestStanzaName() string {
+	if cluster.Spec.Backup != nil &&
+		cluster.Spec.Backup.PgBackRest != nil &&
+		cluster.Spec.Backup.PgBackRest.StanzaName != "" {
+		return cluster.Spec.Backup.PgBackRest.StanzaName
+	}
+	return cluster.Name
+}
+
 // IsBarmanEndpointCASet returns true if we have a CA bundle for the endpoint
 // false otherwise
 func (backupConfiguration *BackupConfiguration) IsBarmanEndpointCASet() bool {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1822,6 +1822,35 @@ var _ = Describe("pgBackRest configuration", func() {
 	})
 })
 
+var _ = Describe("pgBackRest stanza name", func() {
+	It("defaults to the cluster name when not configured", func() {
+		cluster := &Cluster{ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"}}
+		Expect(cluster.GetPgBackRestStanzaName()).To(Equal("my-cluster"))
+	})
+
+	It("defaults to the cluster name when pgBackRest has no stanza override", func() {
+		cluster := &Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{PgBackRest: &PgBackRestConfiguration{}},
+			},
+		}
+		Expect(cluster.GetPgBackRestStanzaName()).To(Equal("my-cluster"))
+	})
+
+	It("uses the override, independent of the live cluster name", func() {
+		cluster := &Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool-cluster-xyz"},
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					PgBackRest: &PgBackRestConfiguration{StanzaName: "branch-abc"},
+				},
+			},
+		}
+		Expect(cluster.GetPgBackRestStanzaName()).To(Equal("branch-abc"))
+	})
+})
+
 var _ = Describe("pgBackRest recovery source", func() {
 	It("returns nil when bootstrap is nil", func() {
 		cluster := &Cluster{}

--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -2126,6 +2126,13 @@ spec:
                         - message: exactly one of s3, gcs, or azure must be specified
                           rule: '(has(self.s3) ? 1 : 0) + (has(self.gcs) ? 1 : 0)
                             + (has(self.azure) ? 1 : 0) == 1'
+                      stanzaName:
+                        description: |-
+                          StanzaName is the pgbackrest stanza this cluster archives to. It is the
+                          logical identity of the backup set in the repository (the repo layout is
+                          <repoPath>/{archive,backup}/<stanza>/). When unset it defaults to the
+                          cluster name.
+                        type: string
                     required:
                     - repository
                     type: object

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1576,6 +1576,13 @@ spec:
                         - message: exactly one of s3, gcs, or azure must be specified
                           rule: '(has(self.s3) ? 1 : 0) + (has(self.gcs) ? 1 : 0)
                             + (has(self.azure) ? 1 : 0) == 1'
+                      stanzaName:
+                        description: |-
+                          StanzaName is the pgbackrest stanza this cluster archives to. It is the
+                          logical identity of the backup set in the repository (the repo layout is
+                          <repoPath>/{archive,backup}/<stanza>/). When unset it defaults to the
+                          cluster name.
+                        type: string
                     required:
                     - repository
                     type: object

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1139,7 +1139,7 @@ func (r *InstanceReconciler) reconcilePgBackRestConfig(ctx context.Context, clus
 	// Stanza creation is only needed on the primary — the stanza metadata
 	// lives in S3 and replicas access it directly from there.
 	if isPrimary && !r.pgBackRestStanzaCreated.Load() {
-		if err := pgbackrest.StanzaCreate(ctx, cluster.Name); err != nil {
+		if err := pgbackrest.StanzaCreate(ctx, cluster.GetPgBackRestStanzaName()); err != nil {
 			log.FromContext(ctx).Error(err, "Failed to create pgbackrest stanza, will retry on next reconcile")
 			return nil
 		}

--- a/pkg/client/applyconfiguration/api/v1/pgbackrestconfiguration.go
+++ b/pkg/client/applyconfiguration/api/v1/pgbackrestconfiguration.go
@@ -9,6 +9,11 @@ package v1
 type PgBackRestConfigurationApplyConfiguration struct {
 	Repository *PgBackRestRepositoryApplyConfiguration `json:"repository,omitempty"`
 	Options    *PgBackRestOptionsApplyConfiguration    `json:"options,omitempty"`
+	// StanzaName is the pgbackrest stanza this cluster archives to. It is the
+	// logical identity of the backup set in the repository (the repo layout is
+	// <repoPath>/{archive,backup}/<stanza>/). When unset it defaults to the
+	// cluster name.
+	StanzaName *string `json:"stanzaName,omitempty"`
 }
 
 // PgBackRestConfigurationApplyConfiguration constructs a declarative configuration of the PgBackRestConfiguration type for use with
@@ -30,5 +35,13 @@ func (b *PgBackRestConfigurationApplyConfiguration) WithRepository(value *PgBack
 // If called multiple times, the Options field is set to the value of the last call.
 func (b *PgBackRestConfigurationApplyConfiguration) WithOptions(value *PgBackRestOptionsApplyConfiguration) *PgBackRestConfigurationApplyConfiguration {
 	b.Options = value
+	return b
+}
+
+// WithStanzaName sets the StanzaName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the StanzaName field is set to the value of the last call.
+func (b *PgBackRestConfigurationApplyConfiguration) WithStanzaName(value string) *PgBackRestConfigurationApplyConfiguration {
+	b.StanzaName = &value
 	return b
 }

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -181,7 +181,7 @@ func internalRun(
 		walPath := filepath.Join(pgData, walName)
 		contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
 
-		err := pgbackrest.ArchivePush(ctx, cluster.Name, walPath)
+		err := pgbackrest.ArchivePush(ctx, cluster.GetPgBackRestStanzaName(), walPath)
 		if err == nil {
 			return nil
 		}
@@ -193,10 +193,10 @@ func internalRun(
 		if pgbackrest.IsStanzaMissingFromRepo(err) {
 			contextLog.Warning("Stanza metadata missing from repository, recreating. " +
 				"Previous backups may be unavailable — a new full backup is recommended")
-			if stanzaErr := pgbackrest.StanzaCreate(ctx, cluster.Name); stanzaErr != nil {
+			if stanzaErr := pgbackrest.StanzaCreate(ctx, cluster.GetPgBackRestStanzaName()); stanzaErr != nil {
 				return fmt.Errorf("failed to recreate stanza after metadata loss: %w", stanzaErr)
 			}
-			return pgbackrest.ArchivePush(ctx, cluster.Name, walPath)
+			return pgbackrest.ArchivePush(ctx, cluster.GetPgBackRestStanzaName(), walPath)
 		}
 
 		return err

--- a/pkg/management/postgres/pgbackrest_backup.go
+++ b/pkg/management/postgres/pgbackrest_backup.go
@@ -135,7 +135,7 @@ func (b *PgBackRestBackupCommand) run(ctx context.Context) {
 	progressCtx, stopProgress := context.WithCancel(ctx)
 	go b.pollProgress(progressCtx)
 
-	err := pgbackrest.Backup(ctx, b.Cluster.Name, string(backupType), annotation)
+	err := pgbackrest.Backup(ctx, b.Cluster.GetPgBackRestStanzaName(), string(backupType), annotation)
 	stopProgress()
 
 	if err != nil {
@@ -179,7 +179,7 @@ func (b *PgBackRestBackupCommand) pollProgress(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			stanza, err := pgbackrest.Info(ctx, b.Cluster.Name)
+			stanza, err := pgbackrest.Info(ctx, b.Cluster.GetPgBackRestStanzaName())
 			if err != nil {
 				b.Log.Info("Progress poll: pgbackrest info failed", "err", err)
 				continue
@@ -210,7 +210,7 @@ func (b *PgBackRestBackupCommand) populateBackupDetails(ctx context.Context) {
 	var err error
 
 	for attempt := 1; attempt <= 3; attempt++ {
-		stanza, err = pgbackrest.Info(ctx, b.Cluster.Name)
+		stanza, err = pgbackrest.Info(ctx, b.Cluster.GetPgBackRestStanzaName())
 		if err == nil {
 			break
 		}

--- a/pkg/pgbackrest/config.go
+++ b/pkg/pgbackrest/config.go
@@ -51,7 +51,7 @@ func GenerateConfig(
 
 	cfg, err := generateBaseConfig(
 		ctx, k8sClient, cluster.Namespace,
-		pgbackrestConfig.Repository, cluster.Name, pgDataPath,
+		pgbackrestConfig.Repository, cluster.GetPgBackRestStanzaName(), pgDataPath,
 	)
 	if err != nil {
 		return "", err
@@ -69,7 +69,10 @@ func GenerateConfig(
 	// the local standby. This enables backup-standby: pgbackrest copies files
 	// locally from the replica while coordinating with the primary over TLS.
 	if !isPrimary {
-		configureReplicaStanza(cfg.Section(cluster.Name), cluster.Name, pgDataPath)
+		// The section key is the stanza identity; the clusterName arg is the
+		// live cluster used to reach the primary (pg1-host: <name>-rw), so it
+		// must stay the actual Cluster name even when the stanza is overridden.
+		configureReplicaStanza(cfg.Section(cluster.GetPgBackRestStanzaName()), cluster.Name, pgDataPath)
 	}
 
 	return renderConfig(cfg)
@@ -251,7 +254,10 @@ func applyOptionDefaults(opts *apiv1.PgBackRestOptions, cluster *apiv1.Cluster) 
 		}
 	}
 	if opts.RepoPath == "" {
-		opts.RepoPath = cluster.Name
+		// Default the repo path to the stanza name so that overriding only the
+		// stanza still keeps the whole backup set (prefix + stanza) under one
+		// stable location.
+		opts.RepoPath = cluster.GetPgBackRestStanzaName()
 	}
 }
 

--- a/pkg/pgbackrest/config_test.go
+++ b/pkg/pgbackrest/config_test.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/xataio/xata-cnpg/api/v1"
@@ -489,5 +490,122 @@ func TestConfigureReplicaStanza(t *testing.T) {
 				t.Errorf("expected %s=%s, got %s", tt.key, tt.expected, v)
 			}
 		})
+	}
+}
+
+// TestGenerateConfig_StanzaName verifies that the pgbackrest stanza section and
+// repo1-path follow spec.backup.pgBackRest.stanzaName when set, and otherwise
+// default to the cluster name. This keeps a branch's backups under a stable
+// identity even when the underlying Cluster is recreated (warm-pool wakeups).
+func TestGenerateConfig_StanzaName(t *testing.T) {
+	newCluster := func(name, stanza string) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					PgBackRest: &apiv1.PgBackRestConfiguration{
+						StanzaName: stanza,
+						Repository: &apiv1.PgBackRestRepository{
+							S3: &apiv1.PgBackRestS3{
+								Bucket:             "test-bucket",
+								Region:             "us-east-1",
+								InheritFromIAMRole: true,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		clusterName    string
+		stanzaName     string
+		wantStanza     string
+		wantRepoPath   string
+		absentSections []string
+	}{
+		"defaults to cluster name when stanza unset": {
+			clusterName:  "pool-cluster-xyz",
+			stanzaName:   "",
+			wantStanza:   "pool-cluster-xyz",
+			wantRepoPath: "/pool-cluster-xyz",
+		},
+		"uses stanza override for section and repo path": {
+			clusterName:    "pool-cluster-xyz",
+			stanzaName:     "branch-abc",
+			wantStanza:     "branch-abc",
+			wantRepoPath:   "/branch-abc",
+			absentSections: []string{"pool-cluster-xyz"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster := newCluster(tt.clusterName, tt.stanzaName)
+
+			content, err := GenerateConfig(
+				context.Background(), nil, cluster, "/pgdata", true,
+			)
+			if err != nil {
+				t.Fatalf("GenerateConfig failed: %v", err)
+			}
+
+			cfg, err := ini.Load([]byte(content))
+			if err != nil {
+				t.Fatalf("parsing rendered config failed: %v", err)
+			}
+
+			if !cfg.HasSection(tt.wantStanza) {
+				t.Errorf("expected a stanza section %q, sections: %v", tt.wantStanza, cfg.SectionStrings())
+			}
+			if v := cfg.Section(tt.wantStanza).Key("pg1-path").String(); v != "/pgdata" {
+				t.Errorf("expected pg1-path /pgdata in stanza %q, got %q", tt.wantStanza, v)
+			}
+			if v := cfg.Section("global").Key("repo1-path").String(); v != tt.wantRepoPath {
+				t.Errorf("expected repo1-path %s, got %s", tt.wantRepoPath, v)
+			}
+			for _, s := range tt.absentSections {
+				if cfg.HasSection(s) {
+					t.Errorf("did not expect a stanza section named after the live cluster %q", s)
+				}
+			}
+		})
+	}
+}
+
+// TestGenerateConfig_ReplicaStanzaUsesLiveClusterHost verifies that on a
+// replica the stanza section follows the stanza override, but pg1-host still
+// points at the live cluster's -rw service (not the stanza name).
+func TestGenerateConfig_ReplicaStanzaUsesLiveClusterHost(t *testing.T) {
+	cluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-cluster-xyz"},
+		Spec: apiv1.ClusterSpec{
+			Backup: &apiv1.BackupConfiguration{
+				PgBackRest: &apiv1.PgBackRestConfiguration{
+					StanzaName: "branch-abc",
+					Repository: &apiv1.PgBackRestRepository{
+						S3: &apiv1.PgBackRestS3{
+							Bucket:             "test-bucket",
+							Region:             "us-east-1",
+							InheritFromIAMRole: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	content, err := GenerateConfig(context.Background(), nil, cluster, "/pgdata", false)
+	if err != nil {
+		t.Fatalf("GenerateConfig failed: %v", err)
+	}
+	cfg, err := ini.Load([]byte(content))
+	if err != nil {
+		t.Fatalf("parsing rendered config failed: %v", err)
+	}
+
+	if v := cfg.Section("branch-abc").Key("pg1-host").String(); v != "pool-cluster-xyz-rw" {
+		t.Errorf("expected pg1-host pool-cluster-xyz-rw (live cluster), got %q", v)
 	}
 }


### PR DESCRIPTION
We use to default the `stanza` to the cluster id, but I think this doesn't work for pools, because the cluster changes with each wake up.

This change makes the stanza configurable. The repoPath is also configurable (was already before), but now it defaults to the stanza. 

