### PR TITLE
Re-run backups initialization when stanza changes

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1110,6 +1110,16 @@ func (r *InstanceReconciler) ensureSuperuserTimeoutProtection(ctx context.Contex
 }
 
 // reconcilePgBackRestConfig generates and writes the pgbackrest configuration
+// stanzaCreateNeeded reports whether pgbackrest stanza-create must run for the
+// given stanza, based on the stanza this manager last created (nil if none).
+// It returns true when nothing has been created yet or when the stanza name has
+// changed — e.g. after a warm-pool cluster is adopted and its stanza switches
+// from the cluster name to the branch id — so the new stanza is initialized
+// rather than skipped because "a stanza was already created".
+func stanzaCreateNeeded(lastCreated *string, stanza string) bool {
+	return lastCreated == nil || *lastCreated != stanza
+}
+
 // file when pgbackrest is configured. On first write (or config change), it
 // also creates the pgbackrest stanza.
 func (r *InstanceReconciler) reconcilePgBackRestConfig(ctx context.Context, cluster *apiv1.Cluster) error {
@@ -1137,13 +1147,17 @@ func (r *InstanceReconciler) reconcilePgBackRestConfig(ctx context.Context, clus
 	}
 
 	// Stanza creation is only needed on the primary — the stanza metadata
-	// lives in S3 and replicas access it directly from there.
-	if isPrimary && !r.pgBackRestStanzaCreated.Load() {
-		if err := pgbackrest.StanzaCreate(ctx, cluster.GetPgBackRestStanzaName()); err != nil {
+	// lives in S3 and replicas access it directly from there. We re-run
+	// stanza-create whenever the stanza name changes (not just once), proactively
+	// initializes the new stanza instead of relying on the lazy WAL-archive
+	// recovery path. stanza-create is idempotent.
+	stanza := cluster.GetPgBackRestStanzaName()
+	if isPrimary && stanzaCreateNeeded(r.pgBackRestStanzaCreated.Load(), stanza) {
+		if err := pgbackrest.StanzaCreate(ctx, stanza); err != nil {
 			log.FromContext(ctx).Error(err, "Failed to create pgbackrest stanza, will retry on next reconcile")
 			return nil
 		}
-		r.pgBackRestStanzaCreated.Store(true)
+		r.pgBackRestStanzaCreated.Store(&stanza)
 	}
 
 	// Start the pgbackrest TLS server if not already running.

--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -58,7 +58,11 @@ type InstanceReconciler struct {
 	certificateReconciler *instancecertificate.Reconciler
 	pluginRepository      repository.Interface
 
-	pgBackRestStanzaCreated atomic.Bool
+	// pgBackRestStanzaCreated holds the name of the pgbackrest stanza that was
+	// last created by this manager. It is a pointer (not a bool) so that a
+	// change of stanza name triggers stanza-create for the new stanza instead
+	// of being skipped.
+	pgBackRestStanzaCreated atomic.Pointer[string]
 	pgBackRestTLSServer     pgbackrest.TLSServer
 }
 

--- a/internal/management/controller/pgbackrest_stanza_test.go
+++ b/internal/management/controller/pgbackrest_stanza_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("pgbackrest stanzaCreateNeeded", func() {
+	It("returns true when no stanza has been created yet", func() {
+		Expect(stanzaCreateNeeded(nil, "branch-abc")).To(BeTrue())
+	})
+
+	It("returns false when the same stanza was already created", func() {
+		Expect(stanzaCreateNeeded(ptr.To("branch-abc"), "branch-abc")).To(BeFalse())
+	})
+
+	It("returns true when the stanza name changed (e.g. pool cluster adopted by a branch)", func() {
+		// Pool cluster created its own (cluster-name) stanza; on adoption the
+		// stanza switches to the branch id and must be created, not skipped.
+		Expect(stanzaCreateNeeded(ptr.To("pool-cluster-xyz"), "branch-abc")).To(BeTrue())
+	})
+})


### PR DESCRIPTION
From testing, we need pgbackrest to create the stanza folders when the `stanza` is changed. This happens when the cluster is moved from the create pool to the branch owner.

This is the minimal change that does it only when the stanza changes. Claude did report on a potential race with it:

```
  When a warm-pool cluster is adopted, two things are triggered independently by the branch-operator: the
  Cluster spec changes (new stanzaName = branch ID), and a ScheduledBackup with immediate: true is created.
  Fix #1 makes the instance manager's Cluster reconcile proactively run stanza-create for the new stanza —
  but that reconcile and the immediate backup are driven by separate controllers/queues with no ordering
  guarantee between them. In the normal case the reconcile creates the stanza first and the backup succeeds;
  but if the immediate backup fires before the reconcile has created the branch-ID stanza, it hits an empty
  stanza and fails with exit code 55 / "has a stanza-create been performed?" (then WAL archiving lazily
  recreates the stanza ~minutes later, so subsequent backups recover). Fix #1 makes the reconcile usually
  win, but doesn't strictly serialize the two — so if dev shows that failure recurring, the narrow
  guarded-and-warned stanza-create-then-retry in the backup path is the follow-up that closes the window.
```

But I think want to test this first and see if we need a more complex solution, perhaps also when Simona is available.