### PR TITLE
Add suspend annotation for backups

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1355,6 +1355,25 @@ func (cluster *Cluster) GetPgBackRestStanzaName() string {
 	return cluster.Name
 }
 
+// IsPgBackRestSuspended reports whether pgbackrest is configured but suspended on
+// this cluster (the PgBackRestSuspended annotation). While suspended, the instance
+// manager no-ops WAL archive-push and skips stanza-create, so the cluster has
+// no pgbackrest footprint in object storage; archive_mode stays "on" so
+// clearing the flag activates archiving without a restart.
+//
+// Transition contract:
+//   - Suspended -> Active on a NEW stanza (warm-pool create): safe — the first
+//     full backup establishes the recovery baseline.
+//   - Suspended -> Active reusing an existing stanza with continuous data
+//     (warm-pool wake-up): safe — the WAL chain stays contiguous.
+//   - Active -> Suspended: WAL produced while suspended is recycled, never
+//     archived (a permanent gap). Only safe for throwaway clusters, or when a
+//     fresh full backup is taken after returning to Active; PITR into the
+//     suspended window is not possible.
+func (cluster *Cluster) IsPgBackRestSuspended() bool {
+	return utils.IsPgBackRestSuspended(&cluster.ObjectMeta)
+}
+
 // IsBarmanEndpointCASet returns true if we have a CA bundle for the endpoint
 // false otherwise
 func (backupConfiguration *BackupConfiguration) IsBarmanEndpointCASet() bool {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1851,6 +1851,29 @@ var _ = Describe("pgBackRest stanza name", func() {
 	})
 })
 
+var _ = Describe("pgBackRest suspended", func() {
+	It("is not suspended when the annotation is absent", func() {
+		cluster := &Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c"}}
+		Expect(cluster.IsPgBackRestSuspended()).To(BeFalse())
+	})
+
+	It("is suspended when the annotation is set to enabled", func() {
+		cluster := &Cluster{ObjectMeta: metav1.ObjectMeta{
+			Name:        "c",
+			Annotations: map[string]string{utils.PgBackRestSuspended: "enabled"},
+		}}
+		Expect(cluster.IsPgBackRestSuspended()).To(BeTrue())
+	})
+
+	It("is not suspended for any other annotation value", func() {
+		cluster := &Cluster{ObjectMeta: metav1.ObjectMeta{
+			Name:        "c",
+			Annotations: map[string]string{utils.PgBackRestSuspended: "disabled"},
+		}}
+		Expect(cluster.IsPgBackRestSuspended()).To(BeFalse())
+	})
+})
+
 var _ = Describe("pgBackRest recovery source", func() {
 	It("returns nil when bootstrap is nil", func() {
 		cluster := &Cluster{}

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1151,8 +1151,12 @@ func (r *InstanceReconciler) reconcilePgBackRestConfig(ctx context.Context, clus
 	// stanza-create whenever the stanza name changes (not just once), proactively
 	// initializes the new stanza instead of relying on the lazy WAL-archive
 	// recovery path. stanza-create is idempotent.
+	// While suspended, skip stanza-create so the cluster leaves no footprint in
+	// object storage; it runs on the next reconcile once the flag is cleared
+	// (e.g. on warm-pool adoption). archive_mode is untouched, so this is
+	// restart-free.
 	stanza := cluster.GetPgBackRestStanzaName()
-	if isPrimary && stanzaCreateNeeded(r.pgBackRestStanzaCreated.Load(), stanza) {
+	if isPrimary && !cluster.IsPgBackRestSuspended() && stanzaCreateNeeded(r.pgBackRestStanzaCreated.Load(), stanza) {
 		if err := pgbackrest.StanzaCreate(ctx, stanza); err != nil {
 			log.FromContext(ctx).Error(err, "Failed to create pgbackrest stanza, will retry on next reconcile")
 			return nil

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -178,6 +178,15 @@ func internalRun(
 
 	// Archive via pgbackrest if configured
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.IsPgBackRestConfigured() {
+		// When suspended, pgbackrest stays configured but archiving is paused:
+		// report success without pushing, so PostgreSQL recycles the WAL and
+		// nothing is written to object storage. archive_mode stays "on", so
+		// resuming (clearing the flag) is restart-free.
+		if cluster.IsPgBackRestSuspended() {
+			contextLog.Debug("pgbackrest is suspended, skipping WAL archive-push", "walName", walName)
+			return nil
+		}
+
 		walPath := filepath.Join(pgData, walName)
 		contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
 

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -154,6 +154,48 @@ func Run(
 	return internalRun(ctx, pgData, cluster, walName)
 }
 
+// archiveWALViaPgBackRest archives a single WAL segment to the pgbackrest
+// repository. When the cluster is suspended it reports success without pushing
+// (the WAL is recycled, nothing is written to object storage). If the stanza
+// metadata is missing from the repository it recreates the stanza once and
+// retries the push.
+func archiveWALViaPgBackRest(ctx context.Context, cluster *apiv1.Cluster, pgData, walName string) error {
+	contextLog := log.FromContext(ctx)
+
+	// When suspended, pgbackrest stays configured but archiving is paused:
+	// report success without pushing, so PostgreSQL recycles the WAL and nothing
+	// is written to object storage. archive_mode stays "on", so resuming
+	// (clearing the flag) is restart-free.
+	if cluster.IsPgBackRestSuspended() {
+		contextLog.Debug("pgbackrest is suspended, skipping WAL archive-push", "walName", walName)
+		return nil
+	}
+
+	walPath := filepath.Join(pgData, walName)
+	contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
+
+	stanza := cluster.GetPgBackRestStanzaName()
+	err := pgbackrest.ArchivePush(ctx, stanza, walPath)
+	if err == nil {
+		return nil
+	}
+
+	// If the stanza metadata (archive.info) was deleted from the repository,
+	// attempt to recreate it. This only succeeds when the S3 path is fully
+	// clean — if partial data remains, stanza-create will fail and the error
+	// is returned for manual intervention.
+	if pgbackrest.IsStanzaMissingFromRepo(err) {
+		contextLog.Warning("Stanza metadata missing from repository, recreating. " +
+			"Previous backups may be unavailable — a new full backup is recommended")
+		if stanzaErr := pgbackrest.StanzaCreate(ctx, stanza); stanzaErr != nil {
+			return fmt.Errorf("failed to recreate stanza after metadata loss: %w", stanzaErr)
+		}
+		return pgbackrest.ArchivePush(ctx, stanza, walPath)
+	}
+
+	return err
+}
+
 func internalRun(
 	ctx context.Context,
 	pgData string,
@@ -178,37 +220,7 @@ func internalRun(
 
 	// Archive via pgbackrest if configured
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.IsPgBackRestConfigured() {
-		// When suspended, pgbackrest stays configured but archiving is paused:
-		// report success without pushing, so PostgreSQL recycles the WAL and
-		// nothing is written to object storage. archive_mode stays "on", so
-		// resuming (clearing the flag) is restart-free.
-		if cluster.IsPgBackRestSuspended() {
-			contextLog.Debug("pgbackrest is suspended, skipping WAL archive-push", "walName", walName)
-			return nil
-		}
-
-		walPath := filepath.Join(pgData, walName)
-		contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
-
-		err := pgbackrest.ArchivePush(ctx, cluster.GetPgBackRestStanzaName(), walPath)
-		if err == nil {
-			return nil
-		}
-
-		// If the stanza metadata (archive.info) was deleted from the repository,
-		// attempt to recreate it. This only succeeds when the S3 path is fully
-		// clean — if partial data remains, stanza-create will fail and the error
-		// is returned for manual intervention.
-		if pgbackrest.IsStanzaMissingFromRepo(err) {
-			contextLog.Warning("Stanza metadata missing from repository, recreating. " +
-				"Previous backups may be unavailable — a new full backup is recommended")
-			if stanzaErr := pgbackrest.StanzaCreate(ctx, cluster.GetPgBackRestStanzaName()); stanzaErr != nil {
-				return fmt.Errorf("failed to recreate stanza after metadata loss: %w", stanzaErr)
-			}
-			return pgbackrest.ArchivePush(ctx, cluster.GetPgBackRestStanzaName(), walPath)
-		}
-
-		return err
+		return archiveWALViaPgBackRest(ctx, cluster, pgData, walName)
 	}
 
 	// Request Barman Cloud to archive this WAL

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -200,13 +200,13 @@ const (
 	// SkipWalArchiving is the name of the annotation which turns off WAL archiving
 	SkipWalArchiving = MetadataNamespace + "/skipWalArchiving"
 
-	// PgBackRestSuspended, when set to "enabled", keeps pgbackrest configured but
-	// suspended: the instance manager no-ops WAL archive-push and skips
-	// stanza-create, so the cluster has no footprint in object storage. Unlike
-	// SkipWalArchiving it does NOT touch archive_mode (which stays "on"), so
-	// toggling suspension never restarts PostgreSQL. Used for warm-pool clusters
-	// (no S3 footprint until adopted) and reusable to suspend archiving during
-	// an initial bulk data load.
+	// PgBackRestSuspended is the annotation that, when set to "enabled", keeps
+	// pgbackrest configured but suspended: the instance manager no-ops WAL
+	// archive-push and skips stanza-create, so the cluster has no footprint in
+	// object storage. Unlike SkipWalArchiving it does NOT touch archive_mode
+	// (which stays "on"), so toggling suspension never restarts PostgreSQL. Used
+	// for warm-pool clusters (no S3 footprint until adopted) and reusable to
+	// suspend archiving during an initial bulk data load.
 	PgBackRestSuspended = MetadataNamespace + "/pgBackRestSuspended"
 
 	// skipEmptyWalArchiveCheck is the name of the annotation which turns off the checks that ensure that the WAL

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -200,6 +200,15 @@ const (
 	// SkipWalArchiving is the name of the annotation which turns off WAL archiving
 	SkipWalArchiving = MetadataNamespace + "/skipWalArchiving"
 
+	// PgBackRestSuspended, when set to "enabled", keeps pgbackrest configured but
+	// suspended: the instance manager no-ops WAL archive-push and skips
+	// stanza-create, so the cluster has no footprint in object storage. Unlike
+	// SkipWalArchiving it does NOT touch archive_mode (which stays "on"), so
+	// toggling suspension never restarts PostgreSQL. Used for warm-pool clusters
+	// (no S3 footprint until adopted) and reusable to suspend archiving during
+	// an initial bulk data load.
+	PgBackRestSuspended = MetadataNamespace + "/pgBackRestSuspended"
+
 	// skipEmptyWalArchiveCheck is the name of the annotation which turns off the checks that ensure that the WAL
 	// archive is empty before writing data
 	skipEmptyWalArchiveCheck = MetadataNamespace + "/skipEmptyWalArchiveCheck"
@@ -530,6 +539,13 @@ func IsPodSpecReconciliationDisabled(object *metav1.ObjectMeta) bool {
 // storage is empty
 func IsEmptyWalArchiveCheckEnabled(object *metav1.ObjectMeta) bool {
 	return object.Annotations[skipEmptyWalArchiveCheck] != string(annotationStatusEnabled)
+}
+
+// IsPgBackRestSuspended returns true when pgbackrest archiving and stanza
+// creation are suspended via the PgBackRestSuspended annotation. archive_mode is
+// unaffected (stays "on"), so toggling suspension does not restart PostgreSQL.
+func IsPgBackRestSuspended(object *metav1.ObjectMeta) bool {
+	return object.Annotations[PgBackRestSuspended] == string(annotationStatusEnabled)
 }
 
 // IsWalArchivingDisabled returns a boolean indicating if PostgreSQL not archive


### PR DESCRIPTION
This adds a way (via an annotation) to suspend pushing backups (WALs and stanza creation) to S3.

It's different from `archive_mode`, because `archive_mode=off` doesn't run the archiver at all. But in turn requires a restart.

For our warm pools, we don't want a restart. This annotation disables the backups with a short-circuit in the manager archiver, and therefore doesn't require a Postgres restart.