### PR TITLE
[pgbackrest] Retry pgbackrest backup if lock is taken

### DIFF
--- a/pkg/management/postgres/pgbackrest_backup.go
+++ b/pkg/management/postgres/pgbackrest_backup.go
@@ -41,15 +41,11 @@ import (
 // backup in the repository to the Kubernetes Backup CR that triggered it.
 const AnnotationKeyBackupCR = "backup-cr"
 
-// backupLockRetryAttempts and backupLockRetryDelay bound how long a backup waits
-// for a competing pgbackrest process to release the shared "backup" lock before
-// giving up. The common case is a backup triggered at cluster adoption racing
-// the stanza-create that runs on the same event; stanza-create releases the lock
-// within a second or two, so a short, bounded retry resolves it while still
-// failing reasonably fast if another backup is genuinely in progress.
+// backupRetryAttempts and backupRetryInitialDelay bound how aggressively a
+// failed pgbackrest backup is retried.
 const (
-	backupLockRetryAttempts = 6
-	backupLockRetryDelay    = 5 * time.Second
+	backupRetryAttempts     = 4
+	backupRetryInitialDelay = 10 * time.Second
 )
 
 // PgBackRestBackupCommand represents a pgbackrest backup being executed.
@@ -146,7 +142,7 @@ func (b *PgBackRestBackupCommand) run(ctx context.Context) {
 	progressCtx, stopProgress := context.WithCancel(ctx)
 	go b.pollProgress(progressCtx)
 
-	err := b.runBackupWithLockRetry(ctx, b.Cluster.GetPgBackRestStanzaName(), string(backupType), annotation)
+	err := b.runBackupWithRetry(ctx, b.Cluster.GetPgBackRestStanzaName(), string(backupType), annotation)
 	stopProgress()
 
 	if err != nil {
@@ -179,33 +175,41 @@ func (b *PgBackRestBackupCommand) run(ctx context.Context) {
 	}
 }
 
-// runBackupWithLockRetry runs a pgbackrest backup, retrying when it fails
-// because it could not acquire the backup lock. stanza-create and backup share
-// pgbackrest's "backup" lock, so a backup triggered at cluster adoption can race
-// the stanza-create that runs on the same event and fail with a lock-acquire
-// error. That contention is transient — stanza-create releases the lock within a
-// second or two — so we retry a bounded number of times. Any non-lock error
-// (and a still-held lock after all attempts) is returned to fail the backup.
-func (b *PgBackRestBackupCommand) runBackupWithLockRetry(
+// runBackupWithRetry runs a pgbackrest backup, retrying on any failure up to
+// backupRetryAttempts with exponential backoff. Early backups commonly fail for
+// transient reasons — racing the adoption-time stanza-create (lock contention or
+// the stanza not yet existing), a transient S3 error, a pod rollout. The lockContention
+// flag in the log distinguishes the most common cause. A backup that keeps
+// failing after all attempts (e.g. genuine misconfiguration) is returned so the
+// Backup CR is marked failed.
+func (b *PgBackRestBackupCommand) runBackupWithRetry(
 	ctx context.Context, stanza, backupType, annotation string,
 ) error {
+	delay := backupRetryInitialDelay
 	var err error
-	for attempt := 1; attempt <= backupLockRetryAttempts; attempt++ {
-		err = pgbackrest.Backup(ctx, stanza, backupType, annotation)
-		if err == nil || !pgbackrest.IsLockBusy(err) {
-			return err
+	for attempt := 1; attempt <= backupRetryAttempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 
-		if attempt < backupLockRetryAttempts {
-			b.Log.Info("pgbackrest backup could not acquire the lock, retrying",
-				"attempt", attempt, "maxAttempts", backupLockRetryAttempts,
-				"retryDelay", backupLockRetryDelay.String(), "error", err.Error())
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backupLockRetryDelay):
-			}
+		err = pgbackrest.Backup(ctx, stanza, backupType, annotation)
+		if err == nil {
+			return nil
 		}
+		if attempt == backupRetryAttempts {
+			break
+		}
+
+		b.Log.Info("pgbackrest backup failed, retrying",
+			"attempt", attempt, "maxAttempts", backupRetryAttempts,
+			"retryDelay", delay.String(), "lockContention", pgbackrest.IsLockBusy(err),
+			"error", err.Error())
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
 	}
 	return err
 }

--- a/pkg/management/postgres/pgbackrest_backup.go
+++ b/pkg/management/postgres/pgbackrest_backup.go
@@ -41,6 +41,17 @@ import (
 // backup in the repository to the Kubernetes Backup CR that triggered it.
 const AnnotationKeyBackupCR = "backup-cr"
 
+// backupLockRetryAttempts and backupLockRetryDelay bound how long a backup waits
+// for a competing pgbackrest process to release the shared "backup" lock before
+// giving up. The common case is a backup triggered at cluster adoption racing
+// the stanza-create that runs on the same event; stanza-create releases the lock
+// within a second or two, so a short, bounded retry resolves it while still
+// failing reasonably fast if another backup is genuinely in progress.
+const (
+	backupLockRetryAttempts = 6
+	backupLockRetryDelay    = 5 * time.Second
+)
+
 // PgBackRestBackupCommand represents a pgbackrest backup being executed.
 type PgBackRestBackupCommand struct {
 	Cluster  *apiv1.Cluster
@@ -135,7 +146,7 @@ func (b *PgBackRestBackupCommand) run(ctx context.Context) {
 	progressCtx, stopProgress := context.WithCancel(ctx)
 	go b.pollProgress(progressCtx)
 
-	err := pgbackrest.Backup(ctx, b.Cluster.GetPgBackRestStanzaName(), string(backupType), annotation)
+	err := b.runBackupWithLockRetry(ctx, b.Cluster.GetPgBackRestStanzaName(), string(backupType), annotation)
 	stopProgress()
 
 	if err != nil {
@@ -166,6 +177,37 @@ func (b *PgBackRestBackupCommand) run(ctx context.Context) {
 	}); err != nil {
 		b.Log.Error(err, "Can't update the cluster with the completed backup data")
 	}
+}
+
+// runBackupWithLockRetry runs a pgbackrest backup, retrying when it fails
+// because it could not acquire the backup lock. stanza-create and backup share
+// pgbackrest's "backup" lock, so a backup triggered at cluster adoption can race
+// the stanza-create that runs on the same event and fail with a lock-acquire
+// error. That contention is transient — stanza-create releases the lock within a
+// second or two — so we retry a bounded number of times. Any non-lock error
+// (and a still-held lock after all attempts) is returned to fail the backup.
+func (b *PgBackRestBackupCommand) runBackupWithLockRetry(
+	ctx context.Context, stanza, backupType, annotation string,
+) error {
+	var err error
+	for attempt := 1; attempt <= backupLockRetryAttempts; attempt++ {
+		err = pgbackrest.Backup(ctx, stanza, backupType, annotation)
+		if err == nil || !pgbackrest.IsLockBusy(err) {
+			return err
+		}
+
+		if attempt < backupLockRetryAttempts {
+			b.Log.Info("pgbackrest backup could not acquire the lock, retrying",
+				"attempt", attempt, "maxAttempts", backupLockRetryAttempts,
+				"retryDelay", backupLockRetryDelay.String(), "error", err.Error())
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backupLockRetryDelay):
+			}
+		}
+	}
+	return err
 }
 
 // pollProgress periodically checks pgbackrest info for backup progress

--- a/pkg/pgbackrest/command.go
+++ b/pkg/pgbackrest/command.go
@@ -67,6 +67,25 @@ func IsStanzaMissingFromRepo(err error) bool {
 	return cmdErr.ExitCode == 103 && strings.Contains(cmdErr.Stderr, "FileMissingError")
 }
 
+// lockAcquireExitCode is the pgbackrest exit code (LockAcquireError) returned
+// when a command cannot acquire its lock because another pgbackrest process is
+// already holding it.
+const lockAcquireExitCode = 50
+
+// IsLockBusy reports whether a pgbackrest error indicates the command could not
+// acquire its lock because another pgbackrest process holds it. stanza-create,
+// backup and expire all share pgbackrest's "backup" lock, so a backup triggered
+// at cluster adoption can race the stanza-create that runs on the same event and
+// fail with this error. The contention is transient — it clears as soon as the
+// other process releases the lock — so callers can safely retry.
+func IsLockBusy(err error) bool {
+	var cmdErr *CommandError
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	return cmdErr.ExitCode == lockAcquireExitCode
+}
+
 // CommandError is returned when a pgbackrest command fails.
 type CommandError struct {
 	// Command is the pgbackrest subcommand that failed (e.g. "archive-push").

--- a/pkg/pgbackrest/command_test.go
+++ b/pkg/pgbackrest/command_test.go
@@ -148,3 +148,48 @@ func TestIsStanzaMissingFromRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLockBusy(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			"lock acquire failure with exit 50",
+			&CommandError{
+				Command:  "backup",
+				ExitCode: 50,
+				Stderr:   "ERROR: [050]: unable to acquire lock on file '/.../stanza-backup-1.lock': Resource temporarily unavailable",
+			},
+			true,
+		},
+		{
+			"different exit code",
+			&CommandError{
+				Command:  "backup",
+				ExitCode: 1,
+				Stderr:   "some other failure",
+			},
+			false,
+		},
+		{
+			"nil error",
+			nil,
+			false,
+		},
+		{
+			"non-CommandError",
+			fmt.Errorf("some error"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLockBusy(tt.err); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/pgbackrest/command_test.go
+++ b/pkg/pgbackrest/command_test.go
@@ -160,7 +160,7 @@ func TestIsLockBusy(t *testing.T) {
 			&CommandError{
 				Command:  "backup",
 				ExitCode: 50,
-				Stderr:   "ERROR: [050]: unable to acquire lock on file '/.../stanza-backup-1.lock': Resource temporarily unavailable",
+				Stderr:   "ERROR: [050]: unable to acquire lock: Resource temporarily unavailable",
 			},
 			true,
 		},


### PR DESCRIPTION
During testing I hit a race condition that seem to affect the branches from the create pool. What happens is that when the cluster is adopted, the stanza create and the full backup are called about the same time.

If the full backup finds the pgbackrest lock taken, it returns an error and doesn't retry. Example log:

```
{"level":"error","ts":"2026-06-04T14:39:25.929422757Z","msg":"Backup failed","backupName":"sqv5dbu9eh1fjabe45svf48dh0-20260604143925","backupNamespace":"xata-clusters","logging_pod":"ci9vrkaogd0kn8emt8l07sh1g8-1","error":"pgbackrest backup failed (exit code 50): 2026-06-04 14:39:25.903 P00   WARN: unable to open log file '/var/lib/postgresql/data/pgbackrest/log/sqv5dbu9eh1fjabe45svf48dh0-backup.log': No such file or directory\n                                    NOTE: process will continue without log file.\n2026-06-04 14:39:25.928 P00  ERROR: [050]: unable to acquire lock on file '/var/lib/postgresql/data/pgbackrest/lock/sqv5dbu9eh1fjabe45svf48dh0-backup-1.lock': Resource temporarily unavailable\n                                    HINT: is another pgBackRest process running?\n","stacktrace":"github.com/cloudnative-pg/machinery/pkg/log.(*logger).Error\n\tpkg/mod/github.com/cloudnative-pg/machinery@v0.3.3/pkg/log/log.go:125\ngithub.com/xataio/xata-cnpg/pkg/management/postgres.(*PgBackRestBackupCommand).run\n\tpkg/management/postgres/pgbackrest_backup.go:142"}
```

The fix makes the full backup retry a few times if the lock is taken.

There is still a possibility that the full backup takes the lock before the stanza and then the stanza creation might fail. I'm not sure how to test that part, but for now I think it makes sense to fix in one direction because we know this actually happens in practice.