### PR TITLE
Regenerate `applyconfiguration` types

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ permissions: read-all
 # set up environment variables to be used across all the jobs
 env:
   # renovate: datasource=golang-version depName=golang versioning=loose
-  GOLANG_VERSION: "1.26.3"
+  GOLANG_VERSION: "1.26.4"
   # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=loose
   GOLANGCI_LINT_VERSION: "v2.10.1"
   KUBEBUILDER_VERSION: "2.3.1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xataio/xata-cnpg
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/client/applyconfiguration/api/v1/pgbouncerspec.go
+++ b/pkg/client/applyconfiguration/api/v1/pgbouncerspec.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	apiv1 "github.com/xataio/xata-cnpg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
@@ -50,6 +51,14 @@ type PgBouncerSpecApplyConfiguration struct {
 	// client connections until this value is set to `false` (default). Internally,
 	// the operator calls PgBouncer's `PAUSE` and `RESUME` commands.
 	Paused *bool `json:"paused,omitempty"`
+	// PauseDuringSwitchover when true, automatically pauses this pooler
+	// during switchover/failover operations on the referenced cluster
+	// to minimize client connection failures.
+	PauseDuringSwitchover *bool `json:"pauseDuringSwitchover,omitempty"`
+	// PauseDuringSwitchoverTimeout is the maximum duration to keep the pooler
+	// paused during switchover. If the switchover doesn't complete within
+	// this time, the pooler will be automatically resumed.
+	PauseDuringSwitchoverTimeout *metav1.Duration `json:"pauseDuringSwitchoverTimeout,omitempty"`
 }
 
 // PgBouncerSpecApplyConfiguration constructs a declarative configuration of the PgBouncerSpec type for use with
@@ -143,5 +152,21 @@ func (b *PgBouncerSpecApplyConfiguration) WithPgHBA(values ...string) *PgBouncer
 // If called multiple times, the Paused field is set to the value of the last call.
 func (b *PgBouncerSpecApplyConfiguration) WithPaused(value bool) *PgBouncerSpecApplyConfiguration {
 	b.Paused = &value
+	return b
+}
+
+// WithPauseDuringSwitchover sets the PauseDuringSwitchover field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PauseDuringSwitchover field is set to the value of the last call.
+func (b *PgBouncerSpecApplyConfiguration) WithPauseDuringSwitchover(value bool) *PgBouncerSpecApplyConfiguration {
+	b.PauseDuringSwitchover = &value
+	return b
+}
+
+// WithPauseDuringSwitchoverTimeout sets the PauseDuringSwitchoverTimeout field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PauseDuringSwitchoverTimeout field is set to the value of the last call.
+func (b *PgBouncerSpecApplyConfiguration) WithPauseDuringSwitchoverTimeout(value metav1.Duration) *PgBouncerSpecApplyConfiguration {
+	b.PauseDuringSwitchoverTimeout = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/api/v1/poolerstatus.go
+++ b/pkg/client/applyconfiguration/api/v1/poolerstatus.go
@@ -11,6 +11,10 @@ type PoolerStatusApplyConfiguration struct {
 	Secrets *PoolerSecretsApplyConfiguration `json:"secrets,omitempty"`
 	// The number of pods trying to be scheduled
 	Instances *int32 `json:"instances,omitempty"`
+	// PausedForSwitchover indicates this pooler was automatically paused for switchover
+	PausedForSwitchover *bool `json:"pausedForSwitchover,omitempty"`
+	// PausedForSwitchoverTimestamp is when this pooler was paused (RFC3339Micro)
+	PausedForSwitchoverTimestamp *string `json:"pausedForSwitchoverTimestamp,omitempty"`
 }
 
 // PoolerStatusApplyConfiguration constructs a declarative configuration of the PoolerStatus type for use with
@@ -32,5 +36,21 @@ func (b *PoolerStatusApplyConfiguration) WithSecrets(value *PoolerSecretsApplyCo
 // If called multiple times, the Instances field is set to the value of the last call.
 func (b *PoolerStatusApplyConfiguration) WithInstances(value int32) *PoolerStatusApplyConfiguration {
 	b.Instances = &value
+	return b
+}
+
+// WithPausedForSwitchover sets the PausedForSwitchover field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PausedForSwitchover field is set to the value of the last call.
+func (b *PoolerStatusApplyConfiguration) WithPausedForSwitchover(value bool) *PoolerStatusApplyConfiguration {
+	b.PausedForSwitchover = &value
+	return b
+}
+
+// WithPausedForSwitchoverTimestamp sets the PausedForSwitchoverTimestamp field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PausedForSwitchoverTimestamp field is set to the value of the last call.
+func (b *PoolerStatusApplyConfiguration) WithPausedForSwitchoverTimestamp(value string) *PoolerStatusApplyConfiguration {
+	b.PausedForSwitchoverTimestamp = &value
 	return b
 }


### PR DESCRIPTION
Update the `applyconfiguration` types after they become out of sync following the CRD changes in https://github.com/xataio/xata-cnpg/pull/34.