### PR TITLE
[Backups] Move backup CR cleanup into the operator (TTL-based)

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -124,24 +124,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	switch backup.Status.Phase {
 	case apiv1.BackupPhaseFailed, apiv1.BackupPhaseCompleted:
-		// TTL: delete the Backup CR 2 hours after completion/failure
-		const backupTTL = 2 * time.Hour
-		var finishedAt time.Time
-		if backup.Status.StoppedAt != nil {
-			finishedAt = backup.Status.StoppedAt.Time
-		} else {
-			finishedAt = backup.CreationTimestamp.Time
-		}
-		age := time.Since(finishedAt)
-		if age >= backupTTL {
-			contextLogger.Info("Deleting expired backup CR",
-				"backup", backup.Name, "phase", backup.Status.Phase, "age", age)
-			if err := r.Delete(ctx, &backup); err != nil && !apierrs.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{RequeueAfter: backupTTL - age}, nil
+		return r.reconcileCompletedBackup(ctx, &backup)
 	}
 
 	var cluster apiv1.Cluster
@@ -241,6 +224,32 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	hookResult := postReconcilePluginHooks(ctx, &cluster, &backup)
 	return hookResult.Result, hookResult.Err
+}
+
+// reconcileCompletedBackup handles TTL-based cleanup of completed or failed Backup CRs.
+// Backups are deleted 2 hours after completion/failure to avoid accumulating stale objects.
+func (r *BackupReconciler) reconcileCompletedBackup(ctx context.Context, backup *apiv1.Backup) (ctrl.Result, error) {
+	const backupTTL = 2 * time.Hour
+	contextLogger := log.FromContext(ctx)
+
+	var finishedAt time.Time
+	if backup.Status.StoppedAt != nil {
+		finishedAt = backup.Status.StoppedAt.Time
+	} else {
+		finishedAt = backup.CreationTimestamp.Time
+	}
+
+	age := time.Since(finishedAt)
+	if age >= backupTTL {
+		contextLogger.Info("Deleting expired backup CR",
+			"backup", backup.Name, "phase", backup.Status.Phase, "age", age)
+		if err := r.Delete(ctx, backup); err != nil && !apierrs.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{RequeueAfter: backupTTL - age}, nil
 }
 
 func (r *BackupReconciler) startBackupManagedByInstance(

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -124,7 +124,24 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	switch backup.Status.Phase {
 	case apiv1.BackupPhaseFailed, apiv1.BackupPhaseCompleted:
-		return ctrl.Result{}, nil
+		// TTL: delete the Backup CR 2 hours after completion/failure
+		const backupTTL = 2 * time.Hour
+		var finishedAt time.Time
+		if backup.Status.StoppedAt != nil {
+			finishedAt = backup.Status.StoppedAt.Time
+		} else {
+			finishedAt = backup.CreationTimestamp.Time
+		}
+		age := time.Since(finishedAt)
+		if age >= backupTTL {
+			contextLogger.Info("Deleting expired backup CR",
+				"backup", backup.Name, "phase", backup.Status.Phase, "age", age)
+			if err := r.Delete(ctx, &backup); err != nil && !apierrs.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{RequeueAfter: backupTTL - age}, nil
 	}
 
 	var cluster apiv1.Cluster

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -25,8 +25,10 @@ import (
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -606,5 +608,99 @@ var _ = Describe("checkPrerequisites for pgBackRest backups", func() {
 		Expect(expectErr).ToNot(HaveOccurred())
 		Expect(stored.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
 		Expect(stored.Status.Method).To(BeEquivalentTo(apiv1.BackupMethodPgBackRest))
+	})
+})
+
+var _ = Describe("backup TTL cleanup", func() {
+	var env *testingEnvironment
+	BeforeEach(func() { env = buildTestEnvironment() })
+
+	It("deletes a completed backup older than 2 hours", func(ctx context.Context) {
+		ns := newFakeNamespace(env.client)
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-completed", Namespace: ns},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: "cluster"},
+				Method:  apiv1.BackupMethodPgBackRest,
+			},
+			Status: apiv1.BackupStatus{
+				Phase:     apiv1.BackupPhaseCompleted,
+				StoppedAt: ptr.To(metav1.NewTime(time.Now().Add(-3 * time.Hour))),
+			},
+		}
+		Expect(env.client.Create(ctx, backup)).To(Succeed())
+
+		res, err := env.backupReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(backup),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		// Backup should be deleted
+		var stored apiv1.Backup
+		err = env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)
+		Expect(apierrs.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("does not delete a completed backup younger than 2 hours", func(ctx context.Context) {
+		ns := newFakeNamespace(env.client)
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Name: "recent-completed", Namespace: ns},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: "cluster"},
+				Method:  apiv1.BackupMethodPgBackRest,
+			},
+			Status: apiv1.BackupStatus{
+				Phase:     apiv1.BackupPhaseCompleted,
+				StoppedAt: ptr.To(metav1.NewTime(time.Now().Add(-30 * time.Minute))),
+			},
+		}
+		Expect(env.client.Create(ctx, backup)).To(Succeed())
+
+		res, err := env.backupReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(backup),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		// Should requeue for the remaining TTL
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(res.RequeueAfter).To(BeNumerically("<=", 90*time.Minute))
+
+		// Backup should still exist
+		var stored apiv1.Backup
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)).To(Succeed())
+	})
+
+	It("deletes a failed backup older than 2 hours using creationTimestamp", func(ctx context.Context) {
+		ns := newFakeNamespace(env.client)
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "old-failed",
+				Namespace:         ns,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-3 * time.Hour)),
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: "cluster"},
+				Method:  apiv1.BackupMethodPgBackRest,
+			},
+			Status: apiv1.BackupStatus{
+				Phase: apiv1.BackupPhaseFailed,
+				// StoppedAt is nil for failed backups
+			},
+		}
+		Expect(env.client.Create(ctx, backup)).To(Succeed())
+
+		res, err := env.backupReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(backup),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		// Backup should be deleted
+		var stored apiv1.Backup
+		err = env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)
+		Expect(apierrs.IsNotFound(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
### What

  Completed and failed Backup CRs are now automatically deleted 2 hours after finishing, directly by the operator's backup reconciler.
 
 ### Why
 We currently have an external backups cleaner job - since before we had access to the cnpg operator code. This cleanup should be done in the reconciler
 
### How

  Added a `reconcileCompletedBackup` method to the backup reconciler. When a Backup CR reaches completed or failed phase, the reconciler requeues it for the remaining TTL (2 hours). Once expired, it deletes the CR.
 Uses `StoppedAt` timestamp when available, falls back to CreationTimestamp for failed backups where StoppedAt is nil.
