### PR TITLE
[WAL Archiving] Fix: WAL files path is malformed

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -163,6 +163,11 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, err
 	}
 
+	// Reconcile pgbackrest configuration if configured
+	if err := r.reconcilePgBackRestConfig(ctx, cluster); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Refresh the cache
 	requeueOnMissingPermissions := r.updateCacheFromCluster(ctx, cluster)
 
@@ -203,15 +208,6 @@ func (r *InstanceReconciler) Reconcile(
 			return handleErrNextLoop(err)
 		}
 		r.firstReconcileDone.Store(true)
-	}
-
-	// Reconcile pgbackrest configuration if configured.
-	// This runs after initialize so that ArchiveAllReadyWALs (called during
-	// initialization of a former primary) can flush leftover WAL files using
-	// the primary config still on disk, before it gets overwritten with the
-	// replica config that includes pg1-host.
-	if err := r.reconcilePgBackRestConfig(ctx, cluster); err != nil {
-		return reconcile.Result{}, err
 	}
 
 	// Reconcile cluster role without DB
@@ -1141,6 +1137,16 @@ func (r *InstanceReconciler) reconcilePgBackRestConfig(ctx context.Context, clus
 	}
 
 	isPrimary := r.instance.GetPodName() == cluster.Status.CurrentPrimary
+	// Before initialization completes, check if PGDATA is still a primary.
+	// This happens during switchover: the cluster status already points to the
+	// new primary, but this pod's PGDATA is still a primary that needs to flush
+	// leftover WAL files via ArchiveAllReadyWALs. Writing the config as primary
+	// (without pg1-host) allows archive-push to run locally.
+	if !isPrimary && !r.firstReconcileDone.Load() {
+		if pgPrimary, _ := r.instance.IsPrimary(); pgPrimary {
+			isPrimary = true
+		}
+	}
 	content, err := pgbackrest.GenerateConfig(ctx, r.GetClient(), cluster, r.instance.PgData, isPrimary)
 	if err != nil {
 		return fmt.Errorf("generating pgbackrest config: %w", err)

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -163,11 +163,6 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, err
 	}
 
-	// Reconcile pgbackrest configuration if configured
-	if err := r.reconcilePgBackRestConfig(ctx, cluster); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// Refresh the cache
 	requeueOnMissingPermissions := r.updateCacheFromCluster(ctx, cluster)
 
@@ -208,6 +203,15 @@ func (r *InstanceReconciler) Reconcile(
 			return handleErrNextLoop(err)
 		}
 		r.firstReconcileDone.Store(true)
+	}
+
+	// Reconcile pgbackrest configuration if configured.
+	// This runs after initialize so that ArchiveAllReadyWALs (called during
+	// initialization of a former primary) can flush leftover WAL files using
+	// the primary config still on disk, before it gets overwritten with the
+	// replica config that includes pg1-host.
+	if err := r.reconcilePgBackRestConfig(ctx, cluster); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// Reconcile cluster role without DB

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -171,7 +171,7 @@ func archiveWALViaPgBackRest(ctx context.Context, cluster *apiv1.Cluster, pgData
 		return nil
 	}
 
-	walPath := filepath.Join(pgData, walName)
+	walPath := postgres.BuildWALPath(pgData, walName)
 	contextLog.Info("Archiving WAL via pgbackrest", "walName", walName, "walPath", walPath)
 
 	stanza := cluster.GetPgBackRestStanzaName()


### PR DESCRIPTION
### What

  Fix two bugs where `ArchiveAllReadyWALs` failed for `pgbackrest` clusters, causing the former primary to get stuck in the demotion loop after a switchover or failover.

 ### Why

  When a primary is demoted (switchover/failover), any unarchived WAL files need to be flushed before `pg_rewind` runs. `ArchiveAllReadyWALs` handles this by iterating .ready files and calling archive-push for each.

  #### Bug 1 — Double `WAL` path

  `GatherReadyWALFiles` returns absolute paths like `/var/lib/postgresql/data/pgdata/pg_wal/000000010000000000000001`.
  But `archiveWALViaPgBackRest` joined this with `pgData` again using `filepath.Join,` producing:
  `/var/lib/postgresql/data/pgdata/var/lib/postgresql/data/pgdata/pg_wal/000000010000000000000001`.
  `pgbackrest` couldn't find the file at this path, so the archive always failed.

  #### Bug 2 — Replica config written before `WAL` flush

  On a former primary's first reconcile after restart, `reconcilePgBackRestConfig` writes the config in replica mode (with pg1-host pointing to the new primary) before `ArchiveAllReadyWALs` runs.
  With pg1-host set, `pgbackrest` refuses to run `archive-push` locally: `archive-push command must be run on the PostgreSQL host` - meaning the primary

The combination of these two bugs meant `ArchiveAllReadyWALs` never succeeded for pgbackrest. 
The former primary got stuck: `ArchiveAllReadyWALs` fails → `pg_rewind` never runs → the pod never becomes a replica.

  This bug affected every pgbackrest cluster where a former primary had unarchived `WAL` files at demotion time. In practice we did not see it because the async archiver usually keeps up and there were no ready files to be sent to S3. It was observed on a production cluster that had WAL archiving backlog due to storage issues(? we think)

  ### How

  Fix 1: Replace `filepath.Join(pgData, walName)` with `postgres.BuildWALPath(pgData, walName)`. `BuildWALPath` already exists and handles both cases: if the path is absolute it returns it as-is, if relative it joins with `pgData`. This is the same function the plugins/barman archiver path already uses.

  Fix 2: In `reconcilePgBackRestConfig`, before initialization has completed (`firstReconcileDone` is false), check if the pod's PGDATA is still a primary via `IsPrimary`(). If so, write the config in primary mode (without pg1-host) so that `ArchiveAllReadyWALs` can run archive-push locally. After initialization completes (`WALs` flushed, `pg_rewind` done, pod demoted), the next reconcile writes the correct replica config.

  ### Testing

  - Deploy to dev
  - Create a 2-instance test cluster, verify normal WAL operations still work
  - Generate WAL backlog (fake the S3 bucket to make archiving fail, then generate traffic)
  - Trigger switchover while WALs are piled up as .ready
  - Restore the real bucket, verify the former primary flushes all WALs, runs pg_rewind, and demotes to replica

  Logs

  Relevant logs pointing at the problem and showing the double path when ArchiveAllReadyWALs runs:
```
  {"level":"info","ts":"2026-06-24T18:55:27.91746946Z","msg":"Detected ready WAL files in a former primary, triggering WAL archiving","logger":"instance-manag
  er","logging_pod":"ml8iphgelt00re03a7sm0h6dto-1","controller":"instance-cluster","controllerGroup":"postgresql.cnpg.io","controllerKind":"Cluster","Cluster"
  :{"name":"ml8iphgelt00re03a7sm0h6dto","namespace":"xata-clusters"},"namespace":"xata-clusters","name":"ml8iphgelt00re03a7sm0h6dto","reconcileID":"bdf6effd-e
  0b6-4228-8347-08f98c71f1ae","logging_pod":"ml8iphgelt00re03a7sm0h6dto-1","readyWALCount":8}
  {"level":"info","ts":"2026-06-24T18:55:27.917647713Z","msg":"Archiving WAL via pgbackrest","logger":"instance-manager","logging_pod":"ml8iphgelt00re03a7sm0h
  6dto-1","controller":"instance-cluster","controllerGroup":"postgresql.cnpg.io","controllerKind":"Cluster","Cluster":{"name":"ml8iphgelt00re03a7sm0h6dto","na
  mespace":"xata-clusters"},"namespace":"xata-clusters","name":"ml8iphgelt00re03a7sm0h6dto","reconcileID":"bdf6effd-e0b6-4228-8347-08f98c71f1ae","logging_pod"
  :"ml8iphgelt00re03a7sm0h6dto-1","walName":"/var/lib/postgresql/data/pgdata/pg_wal/000000010000000000000001","walPath":"/var/lib/postgresql/data/pgdata/var/l
  ib/postgresql/data/pgdata/pg_wal/000000010000000000000001"}
```
  And the pg1-host error after fixing the path:
```  
{"level":"error","ts":"2026-06-25T12:29:17.623Z","msg":"Reconciler error",
  "error":"while ensuring all WAL files are archived: pgbackrest archive-push failed (exit code 72):
  archive-push command must be run on the PostgreSQL host"}
```